### PR TITLE
Ausgewogenere Schwierigkeit bei Klammer-Entfernen-Aufgabe

### DIFF
--- a/src/Tasks/LegalProposition/Quiz.hs
+++ b/src/Tasks/LegalProposition/Quiz.hs
@@ -32,6 +32,7 @@ generateLegalPropositionInst LegalPropositionConfig  {syntaxTreeConfig = SynTree
           atLeastOccurring
           allowArrowOperators
           maxConsecutiveNegations
+          minUniqueBinOperators
         )
       `suchThat` (not . similarExist)
     serialsOfWrong <- vectorOf (fromIntegral illegals) (choose (1, fromIntegral formulas) )`suchThat` listNoDuplicate

--- a/src/Tasks/SubTree/Quiz.hs
+++ b/src/Tasks/SubTree/Quiz.hs
@@ -26,6 +26,7 @@ generateSubTreeInst SubTreeConfig {syntaxTreeConfig = SynTreeConfig {..}, ..} = 
         atLeastOccurring
         allowArrowOperators
         maxConsecutiveNegations
+        minUniqueBinOperators
       `suchThat` \synTree ->
         (allowSameSubTree || noSameSubTree synTree) && fromIntegral (size (allNotLeafSubTrees synTree)) >= minSubTrees
     let correctTrees = allNotLeafSubTrees tree

--- a/src/Tasks/SuperfluousBrackets/Config.hs
+++ b/src/Tasks/SuperfluousBrackets/Config.hs
@@ -25,7 +25,7 @@ data SuperfluousBracketsConfig =
     {
       syntaxTreeConfig :: SynTreeConfig
     , superfluousBracketPairs :: Integer
-    , minUniqueOperators :: Integer
+    , minUniqueBinOperators :: Integer
     } deriving (Show,Generic)
 
 
@@ -36,7 +36,7 @@ defaultSuperfluousBracketsConfig =
     {
       syntaxTreeConfig = defaultSynTreeConfig { allowArrowOperators = True }
     , superfluousBracketPairs = 2
-    , minUniqueOperators = 2
+    , minUniqueBinOperators = 2
     }
 
 
@@ -58,7 +58,7 @@ checkAdditionalConfig SuperfluousBracketsConfig {syntaxTreeConfig=SynTreeConfig 
     | superfluousBracketPairs < 1 = reject $ do
         english "Add at least one extra pair of brackets."
         german "Es muss mindestens ein Klammerpaar hinzugefügt werden."
-    | minUniqueOperators < 1 = reject $ do
+    | minUniqueBinOperators < 1 = reject $ do
         english "There should be at least one operator"
         german "Es sollte mindestens einen Operator geben"
     | otherwise = pure()

--- a/src/Tasks/SuperfluousBrackets/Config.hs
+++ b/src/Tasks/SuperfluousBrackets/Config.hs
@@ -25,7 +25,6 @@ data SuperfluousBracketsConfig =
     {
       syntaxTreeConfig :: SynTreeConfig
     , superfluousBracketPairs :: Integer
-    , minUniqueBinOperators :: Integer
     } deriving (Show,Generic)
 
 
@@ -34,9 +33,8 @@ defaultSuperfluousBracketsConfig :: SuperfluousBracketsConfig
 defaultSuperfluousBracketsConfig =
     SuperfluousBracketsConfig
     {
-      syntaxTreeConfig = defaultSynTreeConfig { allowArrowOperators = True }
+      syntaxTreeConfig = defaultSynTreeConfig { allowArrowOperators = True, minUniqueBinOperators = 2 }
     , superfluousBracketPairs = 2
-    , minUniqueBinOperators = 2
     }
 
 
@@ -58,9 +56,6 @@ checkAdditionalConfig SuperfluousBracketsConfig {syntaxTreeConfig=SynTreeConfig 
     | superfluousBracketPairs < 1 = reject $ do
         english "Add at least one extra pair of brackets."
         german "Es muss mindestens ein Klammerpaar hinzugefügt werden."
-    | minUniqueBinOperators < 1 = reject $ do
-        english "There should be at least one operator"
-        german "Es sollte mindestens einen Operator geben"
     | otherwise = pure()
 
 

--- a/src/Tasks/SuperfluousBrackets/Config.hs
+++ b/src/Tasks/SuperfluousBrackets/Config.hs
@@ -25,6 +25,7 @@ data SuperfluousBracketsConfig =
     {
       syntaxTreeConfig :: SynTreeConfig
     , superfluousBracketPairs :: Integer
+    , minUniqueOperators :: Integer
     } deriving (Show,Generic)
 
 
@@ -35,6 +36,7 @@ defaultSuperfluousBracketsConfig =
     {
       syntaxTreeConfig = defaultSynTreeConfig { allowArrowOperators = True }
     , superfluousBracketPairs = 2
+    , minUniqueOperators = 2
     }
 
 
@@ -56,6 +58,9 @@ checkAdditionalConfig SuperfluousBracketsConfig {syntaxTreeConfig=SynTreeConfig 
     | superfluousBracketPairs < 1 = reject $ do
         english "Add at least one extra pair of brackets."
         german "Es muss mindestens ein Klammerpaar hinzugefügt werden."
+    | minUniqueOperators < 1 = reject $ do
+        english "There should be at least one operator"
+        german "Es sollte mindestens einen Operator geben"
     | otherwise = pure()
 
 

--- a/src/Tasks/SuperfluousBrackets/Quiz.hs
+++ b/src/Tasks/SuperfluousBrackets/Quiz.hs
@@ -26,7 +26,7 @@ generateSuperfluousBracketsInst SuperfluousBracketsConfig {syntaxTreeConfig = Sy
         atLeastOccurring
         allowArrowOperators
         maxConsecutiveNegations
-      `suchThat` (\x -> sameAssociativeOperatorAdjacent x && numOfUniqueOpsInSynTree x > 1)
+      `suchThat` \x -> sameAssociativeOperatorAdjacent x && numOfUniqueOpsInSynTree x > 1
     stringWithSuperfluousBrackets <- superfluousBracketsDisplay tree superfluousBracketPairs
     return $ SuperfluousBracketsInst
       { tree

--- a/src/Tasks/SuperfluousBrackets/Quiz.hs
+++ b/src/Tasks/SuperfluousBrackets/Quiz.hs
@@ -26,7 +26,7 @@ generateSuperfluousBracketsInst SuperfluousBracketsConfig {syntaxTreeConfig = Sy
         atLeastOccurring
         allowArrowOperators
         maxConsecutiveNegations
-      `suchThat` \x -> sameAssociativeOperatorAdjacent x && numOfUniqueOpsInSynTree x > 1
+      `suchThat` \x -> sameAssociativeOperatorAdjacent x && numOfUniqueOpsInSynTree x >= minUniqueOperators
     stringWithSuperfluousBrackets <- superfluousBracketsDisplay tree superfluousBracketPairs
     return $ SuperfluousBracketsInst
       { tree

--- a/src/Tasks/SuperfluousBrackets/Quiz.hs
+++ b/src/Tasks/SuperfluousBrackets/Quiz.hs
@@ -10,7 +10,7 @@ import Test.QuickCheck (Gen, suchThat)
 import Tasks.SuperfluousBrackets.Config (SuperfluousBracketsConfig(..), SuperfluousBracketsInst(..))
 import Tasks.SuperfluousBrackets.PrintSuperfluousBrackets (superfluousBracketsDisplay)
 import Tasks.SynTree.Config (SynTreeConfig(..))
-import Trees.Helpers (sameAssociativeOperatorAdjacent, numOfUniqueBinOpsInSynTree)
+import Trees.Helpers (sameAssociativeOperatorAdjacent)
 import Trees.Generate (genSynTree)
 import Trees.Print (simplestDisplay)
 
@@ -26,7 +26,8 @@ generateSuperfluousBracketsInst SuperfluousBracketsConfig {syntaxTreeConfig = Sy
         atLeastOccurring
         allowArrowOperators
         maxConsecutiveNegations
-      `suchThat` \x -> sameAssociativeOperatorAdjacent x && numOfUniqueBinOpsInSynTree x >= minUniqueBinOperators
+        minUniqueBinOperators
+      `suchThat` sameAssociativeOperatorAdjacent
     stringWithSuperfluousBrackets <- superfluousBracketsDisplay tree superfluousBracketPairs
     return $ SuperfluousBracketsInst
       { tree

--- a/src/Tasks/SuperfluousBrackets/Quiz.hs
+++ b/src/Tasks/SuperfluousBrackets/Quiz.hs
@@ -10,7 +10,7 @@ import Test.QuickCheck (Gen, suchThat)
 import Tasks.SuperfluousBrackets.Config (SuperfluousBracketsConfig(..), SuperfluousBracketsInst(..))
 import Tasks.SuperfluousBrackets.PrintSuperfluousBrackets (superfluousBracketsDisplay)
 import Tasks.SynTree.Config (SynTreeConfig(..))
-import Trees.Helpers (sameAssociativeOperatorAdjacent)
+import Trees.Helpers (sameAssociativeOperatorAdjacent, numOfUniqueOpsInSynTree)
 import Trees.Generate (genSynTree)
 import Trees.Print (simplestDisplay)
 
@@ -26,7 +26,7 @@ generateSuperfluousBracketsInst SuperfluousBracketsConfig {syntaxTreeConfig = Sy
         atLeastOccurring
         allowArrowOperators
         maxConsecutiveNegations
-      `suchThat` sameAssociativeOperatorAdjacent
+      `suchThat` (\x -> sameAssociativeOperatorAdjacent x && numOfUniqueOpsInSynTree x > 1)
     stringWithSuperfluousBrackets <- superfluousBracketsDisplay tree superfluousBracketPairs
     return $ SuperfluousBracketsInst
       { tree

--- a/src/Tasks/SuperfluousBrackets/Quiz.hs
+++ b/src/Tasks/SuperfluousBrackets/Quiz.hs
@@ -10,7 +10,7 @@ import Test.QuickCheck (Gen, suchThat)
 import Tasks.SuperfluousBrackets.Config (SuperfluousBracketsConfig(..), SuperfluousBracketsInst(..))
 import Tasks.SuperfluousBrackets.PrintSuperfluousBrackets (superfluousBracketsDisplay)
 import Tasks.SynTree.Config (SynTreeConfig(..))
-import Trees.Helpers (sameAssociativeOperatorAdjacent, numOfUniqueOpsInSynTree)
+import Trees.Helpers (sameAssociativeOperatorAdjacent, numOfUniqueBinOpsInSynTree)
 import Trees.Generate (genSynTree)
 import Trees.Print (simplestDisplay)
 
@@ -26,7 +26,7 @@ generateSuperfluousBracketsInst SuperfluousBracketsConfig {syntaxTreeConfig = Sy
         atLeastOccurring
         allowArrowOperators
         maxConsecutiveNegations
-      `suchThat` \x -> sameAssociativeOperatorAdjacent x && numOfUniqueOpsInSynTree x >= minUniqueOperators
+      `suchThat` \x -> sameAssociativeOperatorAdjacent x && numOfUniqueBinOpsInSynTree x >= minUniqueBinOperators
     stringWithSuperfluousBrackets <- superfluousBracketsDisplay tree superfluousBracketPairs
     return $ SuperfluousBracketsInst
       { tree

--- a/src/Tasks/SynTree/Config.hs
+++ b/src/Tasks/SynTree/Config.hs
@@ -94,8 +94,11 @@ checkSynTreeConfig SynTreeConfig {..}
         english "Your maximum depth value is unreasonably large, given your other settings."
         german "Maximale Tiefe des Baumes ist zu hoch für eingestellte Parameter."
     | minUniqueBinOperators < 0 = reject $ do
-        english "There should be a positive number of unique operators"
-        german "Es sollte eine positive Anzahl an unterschiedlichen Operatoren geben"
+        english "There should be a non-negative number of unique operators"
+        german "Es sollte eine nicht-negative Anzahl an unterschiedlichen Operatoren geben"
+    | minUniqueBinOperators > fromIntegral (length [minBound .. maxBound :: BinOp]) = reject $ do
+        english "The number of unique operators cannot exceed the maximum number of operators."
+        german "Die Anzahl der unterschiedlichen Operatoren kann nicht die maximale Anzahl überschreiten."
     | otherwise = pure()
 
 

--- a/src/Tasks/SynTree/Config.hs
+++ b/src/Tasks/SynTree/Config.hs
@@ -32,6 +32,7 @@ data SynTreeConfig =
   , allowArrowOperators :: Bool
   , maxConsecutiveNegations :: Integer
   , extraText :: Maybe String
+  , minUniqueBinOperators :: Integer
   } deriving (Show,Generic)
 
 
@@ -47,6 +48,7 @@ defaultSynTreeConfig =
     , allowArrowOperators = False
     , maxConsecutiveNegations = 2
     , extraText = Nothing
+    , minUniqueBinOperators = 0
     }
 
 
@@ -91,6 +93,9 @@ checkSynTreeConfig SynTreeConfig {..}
       = reject $ do
         english "Your maximum depth value is unreasonably large, given your other settings."
         german "Maximale Tiefe des Baumes ist zu hoch für eingestellte Parameter."
+    | minUniqueBinOperators < 0 = reject $ do
+        english "There should be a positive number of unique operators"
+        german "Es sollte eine positive Anzahl an unterschiedlichen Operatoren geben"
     | otherwise = pure()
 
 

--- a/src/Tasks/SynTree/Quiz.hs
+++ b/src/Tasks/SynTree/Quiz.hs
@@ -23,6 +23,7 @@ generateSynTreeInst SynTreeConfig {..} = do
       atLeastOccurring
       allowArrowOperators
       maxConsecutiveNegations
+      minUniqueBinOperators
     return $ SynTreeInst
       { tree
       , latexImage = transferToPicture tree

--- a/src/Trees/Generate.hs
+++ b/src/Trees/Generate.hs
@@ -7,7 +7,7 @@ import Test.QuickCheck (choose, Gen, oneof, shuffle, suchThat, elements)
 import Test.QuickCheck.Gen (vectorOf)
 
 import Trees.Types (SynTree(..), BinOp(..), allBinaryOperators)
-import Trees.Helpers (collectLeaves, relabelShape, maxNodesForDepth, consecutiveNegations)
+import Trees.Helpers (collectLeaves, relabelShape, maxNodesForDepth, consecutiveNegations, numOfUniqueBinOpsInSynTree)
 
 chooseList :: Bool -> [BinOp]
 chooseList allowArrowOperators = if allowArrowOperators
@@ -21,22 +21,23 @@ randomList availableLetters atLeastOccurring listLength = let
         randomRest <- vectorOf restLength (elements availableLetters)
         shuffle (atLeastOccurring ++ randomRest)
 
-genSynTree :: (Integer, Integer) -> Integer -> [c] -> Integer -> Bool -> Integer -> Gen (SynTree BinOp c)
-genSynTree (minNodes, maxNodes) maxDepth availableLetters atLeastOccurring allowArrowOperators maxConsecutiveNegations =
+genSynTree :: (Integer, Integer) -> Integer -> [c] -> Integer -> Bool -> Integer -> Integer -> Gen (SynTree BinOp c)
+genSynTree (minNodes, maxNodes) maxDepth availableLetters atLeastOccurring allowArrowOperators maxConsecutiveNegations minUniqueBinOps =
     if maxConsecutiveNegations /= 0
         then do
         nodes <- choose (minNodes, maxNodes)
         sample <- syntaxShape nodes maxDepth allowArrowOperators True
           `suchThat` \synTree ->
             (fromIntegral (length (collectLeaves synTree)) >= atLeastOccurring) &&
-            consecutiveNegations synTree <= maxConsecutiveNegations
+            consecutiveNegations synTree <= maxConsecutiveNegations &&
+            numOfUniqueBinOpsInSynTree synTree >= minUniqueBinOps
         usedList <- randomList availableLetters (take (fromIntegral atLeastOccurring) availableLetters) $
           fromIntegral $ length $ collectLeaves sample
         return (relabelShape sample usedList )
         else do
         nodes <- choose (minNodes, maxNodes) `suchThat` odd
         sample <- syntaxShape nodes maxDepth allowArrowOperators False
-          `suchThat` \synTree -> fromIntegral (length (collectLeaves synTree)) >= atLeastOccurring
+          `suchThat` \synTree -> fromIntegral (length (collectLeaves synTree)) >= atLeastOccurring && numOfUniqueBinOpsInSynTree synTree >= minUniqueBinOps
         usedList <- randomList availableLetters (take (fromIntegral atLeastOccurring) availableLetters) $
           fromIntegral $ length $ collectLeaves sample
         return (relabelShape sample usedList )

--- a/src/Trees/Generate.hs
+++ b/src/Trees/Generate.hs
@@ -22,7 +22,14 @@ randomList availableLetters atLeastOccurring listLength = let
         shuffle (atLeastOccurring ++ randomRest)
 
 genSynTree :: (Integer, Integer) -> Integer -> [c] -> Integer -> Bool -> Integer -> Integer -> Gen (SynTree BinOp c)
-genSynTree (minNodes, maxNodes) maxDepth availableLetters atLeastOccurring allowArrowOperators maxConsecutiveNegations minUniqueBinOps =
+genSynTree
+  (minNodes, maxNodes)
+  maxDepth
+  availableLetters
+  atLeastOccurring
+  allowArrowOperators
+  maxConsecutiveNegations
+  minUniqueBinOps =
     if maxConsecutiveNegations /= 0
         then do
         nodes <- choose (minNodes, maxNodes)
@@ -37,10 +44,12 @@ genSynTree (minNodes, maxNodes) maxDepth availableLetters atLeastOccurring allow
         else do
         nodes <- choose (minNodes, maxNodes) `suchThat` odd
         sample <- syntaxShape nodes maxDepth allowArrowOperators False
-          `suchThat` \synTree -> fromIntegral (length (collectLeaves synTree)) >= atLeastOccurring && numOfUniqueBinOpsInSynTree synTree >= minUniqueBinOps
+          `suchThat` \synTree -> checkAtLeastOccurring synTree  && checkMinUniqueOps synTree
         usedList <- randomList availableLetters (take (fromIntegral atLeastOccurring) availableLetters) $
           fromIntegral $ length $ collectLeaves sample
         return (relabelShape sample usedList )
+  where checkAtLeastOccurring synTree = fromIntegral (length (collectLeaves synTree)) >= atLeastOccurring
+        checkMinUniqueOps synTree = numOfUniqueBinOpsInSynTree synTree >= minUniqueBinOps
 
 syntaxShape :: Integer -> Integer -> Bool -> Bool -> Gen (SynTree BinOp ())
 syntaxShape nodes maxDepth allowArrowOperators allowNegation

--- a/src/Trees/Helpers.hs
+++ b/src/Trees/Helpers.hs
@@ -20,7 +20,7 @@ module Trees.Helpers
     literalToSynTree,
     numOfOps,
     numOfOpsInFormula,
-    numOfUniqueOpsInSynTree,
+    numOfUniqueOpsInSynTree
     ) where
 
 import Control.Monad (void)
@@ -142,10 +142,9 @@ numOfOpsInFormula (Brackets f) = numOfOpsInFormula f
 numOfOpsInFormula (Assoc _ f1 f2) = 1 + numOfOpsInFormula f1 + numOfOpsInFormula f2
 
 numOfUniqueOpsInSynTree :: SynTree BinOp c -> Integer
-numOfUniqueOpsInSynTree (Leaf _) = 0
-numOfUniqueOpsInSynTree (Not f) = numOfUniqueOpsInSynTree f
-numOfUniqueOpsInSynTree bin = num' bin []
+numOfUniqueOpsInSynTree x = num' x []
   where num' :: SynTree BinOp c -> [BinOp] -> Integer
+        num' (Leaf _) _ = 0
+        num' (Not f) xs = num' f xs
         num' (Binary op sub1 sub2) xs = if op `elem` xs then num' sub1 xs + num' sub2 xs
                                                         else 1 + num' sub1 (op:xs) + num' sub2 (op:xs)
-        num' x _ = numOfUniqueOpsInSynTree x

--- a/src/Trees/Helpers.hs
+++ b/src/Trees/Helpers.hs
@@ -26,7 +26,7 @@ module Trees.Helpers
 import Control.Monad (void)
 import Control.Monad.State (get, put, runState, evalState)
 import Data.Set(fromList, Set, toList)
-import Data.List.Extra (nubBy)
+import Data.List.Extra (nubBy, nubOrd)
 import qualified Data.Foldable as Foldable (toList)
 import qualified Formula.Types as SetFormula hiding (Dnf(..), Con(..))
 import Trees.Types (SynTree(..), BinOp(..), PropFormula(..))
@@ -142,7 +142,7 @@ numOfOpsInFormula (Brackets f) = numOfOpsInFormula f
 numOfOpsInFormula (Assoc _ f1 f2) = 1 + numOfOpsInFormula f1 + numOfOpsInFormula f2
 
 numOfUniqueBinOpsInSynTree :: SynTree BinOp c -> Integer
-numOfUniqueBinOpsInSynTree x = fromIntegral (length (nubBy (==) (ops x)))
+numOfUniqueBinOpsInSynTree x = fromIntegral (length (nubOrd (ops x)))
   where ops :: SynTree BinOp c -> [BinOp]
         ops (Leaf _) = []
         ops (Not f) = ops f

--- a/src/Trees/Helpers.hs
+++ b/src/Trees/Helpers.hs
@@ -19,7 +19,8 @@ module Trees.Helpers
     clauseToSynTree,
     literalToSynTree,
     numOfOps,
-    numOfOpsInFormula
+    numOfOpsInFormula,
+    numOfUniqueOpsInSynTree,
     ) where
 
 import Control.Monad (void)
@@ -139,3 +140,12 @@ numOfOpsInFormula (Atomic _) = 0
 numOfOpsInFormula (Neg f) = numOfOpsInFormula f
 numOfOpsInFormula (Brackets f) = numOfOpsInFormula f
 numOfOpsInFormula (Assoc _ f1 f2) = 1 + numOfOpsInFormula f1 + numOfOpsInFormula f2
+
+numOfUniqueOpsInSynTree :: SynTree BinOp c -> Integer
+numOfUniqueOpsInSynTree (Leaf _) = 0
+numOfUniqueOpsInSynTree (Not f) = numOfUniqueOpsInSynTree f
+numOfUniqueOpsInSynTree bin = num' bin []
+  where num' :: SynTree BinOp c -> [BinOp] -> Integer
+        num' (Binary op sub1 sub2) xs = if op `elem` xs then num' sub1 xs + num' sub2 xs
+                                                        else 1 + num' sub1 (op:xs) + num' sub2 (op:xs)
+        num' x _ = numOfUniqueOpsInSynTree x

--- a/src/Trees/Helpers.hs
+++ b/src/Trees/Helpers.hs
@@ -20,7 +20,7 @@ module Trees.Helpers
     literalToSynTree,
     numOfOps,
     numOfOpsInFormula,
-    numOfUniqueOpsInSynTree
+    numOfUniqueBinOpsInSynTree
     ) where
 
 import Control.Monad (void)
@@ -141,10 +141,9 @@ numOfOpsInFormula (Neg f) = numOfOpsInFormula f
 numOfOpsInFormula (Brackets f) = numOfOpsInFormula f
 numOfOpsInFormula (Assoc _ f1 f2) = 1 + numOfOpsInFormula f1 + numOfOpsInFormula f2
 
-numOfUniqueOpsInSynTree :: SynTree BinOp c -> Integer
-numOfUniqueOpsInSynTree x = num' x []
-  where num' :: SynTree BinOp c -> [BinOp] -> Integer
-        num' (Leaf _) _ = 0
-        num' (Not f) xs = num' f xs
-        num' (Binary op sub1 sub2) xs = if op `elem` xs then num' sub1 xs + num' sub2 xs
-                                                        else 1 + num' sub1 (op:xs) + num' sub2 (op:xs)
+numOfUniqueBinOpsInSynTree :: SynTree BinOp c -> Integer
+numOfUniqueBinOpsInSynTree x = fromIntegral (length (nubBy (==) (ops x)))
+  where ops :: SynTree BinOp c -> [BinOp]
+        ops (Leaf _) = []
+        ops (Not f) = ops f
+        ops (Binary op s1 s2) = concat [[op], ops s1, ops s2]

--- a/test/LegalPropositionSpec.hs
+++ b/test/LegalPropositionSpec.hs
@@ -63,6 +63,7 @@ spec = do
                     atLeastOccurring
                     allowArrowOperators
                     maxConsecutiveNegations
+                    minUniqueBinOperators
                   ) $ \synTree ->
                       forAll (deleteSpaces <$> illegalDisplay synTree) $
                       all (\c -> c `elem` "()∧∨¬<=>" || isLetter c)
@@ -76,6 +77,7 @@ spec = do
                     atLeastOccurring
                     allowArrowOperators
                     maxConsecutiveNegations
+                    minUniqueBinOperators
                   ) $ \synTree ->
                       forAll (illegalDisplay synTree) $ \str -> isLeft (formulaParse str)
     describe "bracket display" $ do
@@ -89,6 +91,7 @@ spec = do
                     atLeastOccurring
                     allowArrowOperators
                     maxConsecutiveNegations
+                    minUniqueBinOperators
                   ) $ \synTree ->
                       forAll (bracketDisplay synTree) $ \str -> length str == length (display synTree) + 2
         it "the String can be parsed by formulaParse" $
@@ -101,6 +104,7 @@ spec = do
                     atLeastOccurring
                     allowArrowOperators
                     maxConsecutiveNegations
+                    minUniqueBinOperators
                   ) $ \synTree ->
                       forAll (bracketDisplay synTree) $ \str -> formulaParse str == Right synTree
         it "the String remove all brackets should same with display remove all brackets" $
@@ -113,6 +117,7 @@ spec = do
                     atLeastOccurring
                     allowArrowOperators
                     maxConsecutiveNegations
+                    minUniqueBinOperators
                   ) $ \synTree ->
                       forAll (bracketDisplay synTree) $ \str -> deleteBrackets str == deleteBrackets (display synTree)
     describe "generateLegalPropositionInst" $ do

--- a/test/SuperfluousBracketsSpec.hs
+++ b/test/SuperfluousBracketsSpec.hs
@@ -13,7 +13,7 @@ import Tasks.SuperfluousBrackets.Config(SuperfluousBracketsConfig(..), Superfluo
 import Tasks.SynTree.Config (SynTreeConfig(..))
 import SynTreeSpec (validBoundsSynTree)
 import Trees.Types (SynTree(..), BinOp(..), PropFormula)
-import Trees.Helpers (numberAllBinaryNodes, sameAssociativeOperatorAdjacent, treeNodes)
+import Trees.Helpers (numberAllBinaryNodes, sameAssociativeOperatorAdjacent, treeNodes, numOfUniqueOpsInSynTree)
 import Trees.Print (display, simplestDisplay)
 import Tasks.SuperfluousBrackets.PrintSuperfluousBrackets (
   superfluousBracketsDisplay,
@@ -129,3 +129,7 @@ spec = do
                 forAll (generateSuperfluousBracketsInst config) $ \SuperfluousBracketsInst{..} ->
                   fromIntegral (length stringWithSuperfluousBrackets - length simplestString)
                     == superfluousBracketPairs * 2
+        it "should not have less than two unique operators" $
+            forAll validBoundsSuperfluousBrackets $ \config@SuperfluousBracketsConfig {..} ->
+                forAll (generateSuperfluousBracketsInst config) $ \SuperfluousBracketsInst{..} ->
+                  numOfUniqueOpsInSynTree tree > 1

--- a/test/SuperfluousBracketsSpec.hs
+++ b/test/SuperfluousBracketsSpec.hs
@@ -32,6 +32,7 @@ validBoundsSuperfluousBrackets = do
         {
           syntaxTreeConfig
         , superfluousBracketPairs
+        , minUniqueOperators = 2
         }
 
 invalidBoundsSuperfluousBrackets :: Gen SuperfluousBracketsConfig
@@ -42,6 +43,7 @@ invalidBoundsSuperfluousBrackets = do
         {
           syntaxTreeConfig
         , superfluousBracketPairs
+        , minUniqueOperators = 2
         }
 
 spec :: Spec
@@ -67,6 +69,15 @@ spec = do
                   ) $ \synTree ->
                     sameAssociativeOperatorAdjacent synTree ==>
                       notNull (sameAssociativeOperatorAdjacentSerial (numberAllBinaryNodes synTree) Nothing)
+    describe "numOfUniqueOpsInSynTree" $ do
+        it "should return 0 if there is only a leaf" $
+            numOfUniqueOpsInSynTree (Leaf 'a') == 0
+        it "should return 1 if there is only one operator" $
+            numOfUniqueOpsInSynTree (Binary Or (Leaf 'a') (Leaf 'b')) == 1
+        it "should return 1 if there are two operators of same kind" $
+            numOfUniqueOpsInSynTree (Binary Or (Leaf 'a') (Not (Binary Or (Leaf 'a') (Leaf 'c')))) == 1
+        it "should return 2 if there are two unique operators" $
+            numOfUniqueOpsInSynTree (Binary Or (Leaf 'a') (Not (Binary And (Leaf 'a') (Leaf 'c')))) == 2
     describe "simplestDisplay and superfluousBracketsDisplay" $ do
         it "simplestDisplay should have less brackets than or equal to normal formula" $
             forAll validBoundsSuperfluousBrackets $
@@ -129,7 +140,7 @@ spec = do
                 forAll (generateSuperfluousBracketsInst config) $ \SuperfluousBracketsInst{..} ->
                   fromIntegral (length stringWithSuperfluousBrackets - length simplestString)
                     == superfluousBracketPairs * 2
-        it "should not have less than two unique operators" $
+        it "should have the right number of unique operators" $
             forAll validBoundsSuperfluousBrackets $ \config@SuperfluousBracketsConfig {..} ->
                 forAll (generateSuperfluousBracketsInst config) $ \SuperfluousBracketsInst{..} ->
-                  numOfUniqueOpsInSynTree tree > 1
+                  numOfUniqueOpsInSynTree tree >= minUniqueOperators

--- a/test/SuperfluousBracketsSpec.hs
+++ b/test/SuperfluousBracketsSpec.hs
@@ -13,7 +13,7 @@ import Tasks.SuperfluousBrackets.Config(SuperfluousBracketsConfig(..), Superfluo
 import Tasks.SynTree.Config (SynTreeConfig(..))
 import SynTreeSpec (validBoundsSynTree)
 import Trees.Types (SynTree(..), BinOp(..), PropFormula)
-import Trees.Helpers (numberAllBinaryNodes, sameAssociativeOperatorAdjacent, treeNodes, numOfUniqueOpsInSynTree)
+import Trees.Helpers (numberAllBinaryNodes, sameAssociativeOperatorAdjacent, treeNodes, numOfUniqueBinOpsInSynTree)
 import Trees.Print (display, simplestDisplay)
 import Tasks.SuperfluousBrackets.PrintSuperfluousBrackets (
   superfluousBracketsDisplay,
@@ -32,7 +32,7 @@ validBoundsSuperfluousBrackets = do
         {
           syntaxTreeConfig
         , superfluousBracketPairs
-        , minUniqueOperators = 2
+        , minUniqueBinOperators = 2
         }
 
 invalidBoundsSuperfluousBrackets :: Gen SuperfluousBracketsConfig
@@ -43,7 +43,7 @@ invalidBoundsSuperfluousBrackets = do
         {
           syntaxTreeConfig
         , superfluousBracketPairs
-        , minUniqueOperators = 2
+        , minUniqueBinOperators = 2
         }
 
 spec :: Spec
@@ -69,15 +69,15 @@ spec = do
                   ) $ \synTree ->
                     sameAssociativeOperatorAdjacent synTree ==>
                       notNull (sameAssociativeOperatorAdjacentSerial (numberAllBinaryNodes synTree) Nothing)
-    describe "numOfUniqueOpsInSynTree" $ do
+    describe "numOfUniqueBinOpsInSynTree" $ do
         it "should return 0 if there is only a leaf" $
-            numOfUniqueOpsInSynTree (Leaf 'a') == 0
+            numOfUniqueBinOpsInSynTree (Leaf 'a') == 0
         it "should return 1 if there is only one operator" $
-            numOfUniqueOpsInSynTree (Binary Or (Leaf 'a') (Leaf 'b')) == 1
+            numOfUniqueBinOpsInSynTree (Binary Or (Leaf 'a') (Leaf 'b')) == 1
         it "should return 1 if there are two operators of same kind" $
-            numOfUniqueOpsInSynTree (Binary Or (Leaf 'a') (Not (Binary Or (Leaf 'a') (Leaf 'c')))) == 1
+            numOfUniqueBinOpsInSynTree (Binary Or (Leaf 'a') (Not (Binary Or (Leaf 'a') (Leaf 'c')))) == 1
         it "should return 2 if there are two unique operators" $
-            numOfUniqueOpsInSynTree (Binary Or (Leaf 'a') (Not (Binary And (Leaf 'a') (Leaf 'c')))) == 2
+            numOfUniqueBinOpsInSynTree (Binary Or (Leaf 'a') (Not (Binary And (Leaf 'a') (Binary And (Leaf 'a') (Leaf 'c'))))) == 2
     describe "simplestDisplay and superfluousBracketsDisplay" $ do
         it "simplestDisplay should have less brackets than or equal to normal formula" $
             forAll validBoundsSuperfluousBrackets $
@@ -143,4 +143,4 @@ spec = do
         it "should have the right number of unique operators" $
             forAll validBoundsSuperfluousBrackets $ \config@SuperfluousBracketsConfig {..} ->
                 forAll (generateSuperfluousBracketsInst config) $ \SuperfluousBracketsInst{..} ->
-                  numOfUniqueOpsInSynTree tree >= minUniqueOperators
+                  numOfUniqueBinOpsInSynTree tree >= minUniqueBinOperators

--- a/test/SynTreeSpec.hs
+++ b/test/SynTreeSpec.hs
@@ -11,8 +11,10 @@ import TestHelpers (deleteSpaces)
 import Trees.Print (display)
 import Trees.Parsing (formulaParse)
 import Tasks.SynTree.Config (SynTreeConfig (..), SynTreeInst (..))
-import Trees.Helpers (collectLeaves, treeDepth, treeNodes, maxLeavesForNodes, maxNodesForDepth, minDepthForNodes)
+import Trees.Helpers (collectLeaves, treeDepth, treeNodes, maxLeavesForNodes, maxNodesForDepth, minDepthForNodes, numOfUniqueBinOpsInSynTree)
 import Tasks.SynTree.Quiz (generateSynTreeInst)
+import Trees.Types (SynTree(..), BinOp(..))
+import Trees.Generate (genSynTree)
 
 validBoundsSynTree :: Gen SynTreeConfig
 validBoundsSynTree = do
@@ -38,7 +40,8 @@ validBoundsSynTree = do
         atLeastOccurring,
         allowArrowOperators,
         maxConsecutiveNegations,
-        extraText = Nothing
+        extraText = Nothing,
+        minUniqueBinOperators = 0
       }
 
 invalidBoundsSynTree :: Gen SynTreeConfig
@@ -57,7 +60,8 @@ invalidBoundsSynTree = do
         atLeastOccurring = fromIntegral (length usedLiterals),
         allowArrowOperators = True,
         maxConsecutiveNegations,
-        extraText = Nothing
+        extraText = Nothing,
+        minUniqueBinOperators = 0
       }
 
 
@@ -68,6 +72,27 @@ spec = do
     it "rejects nonsense" $
       forAll validBoundsSynTree $ \config ->
         forAll (generateSynTreeInst config) $ \SynTreeInst{..} -> formulaParse (tail correct) /= Right tree
+  describe "numOfUniqueBinOpsInSynTree" $ do
+        it "should return 0 if there is only a leaf" $
+            numOfUniqueBinOpsInSynTree (Leaf 'a') == 0
+        it "should return 1 if there is only one operator" $
+            numOfUniqueBinOpsInSynTree (Binary Or (Leaf 'a') (Leaf 'b')) == 1
+        it "should return 1 if there are two operators of same kind" $
+            numOfUniqueBinOpsInSynTree (Binary Or (Leaf 'a') (Not (Binary Or (Leaf 'a') (Leaf 'c')))) == 1
+        it "should return 2 if there are two unique operators" $
+            numOfUniqueBinOpsInSynTree (Binary Or (Leaf 'a') (Not (Binary And (Leaf 'a') (Binary And (Leaf 'a') (Leaf 'c'))))) == 2
+  describe "genSynTree" $ do
+    it "should generate a random SyntaxTree that satisfies the required amount of unique binary operators" $
+      forAll validBoundsSynTree $ \SynTreeConfig {..} ->
+        forAll (genSynTree
+                    (minNodes, maxNodes)
+                    maxDepth
+                    usedLiterals
+                    atLeastOccurring
+                    allowArrowOperators
+                    maxConsecutiveNegations
+                    minUniqueBinOperators
+                  ) $ \synTree -> numOfUniqueBinOpsInSynTree synTree >= minUniqueBinOperators
   describe "genSyntaxTree" $ do
     it "should generate a random SyntaxTree from the given parament and can be parsed by formulaParse" $
       forAll validBoundsSynTree $ \config ->

--- a/test/SynTreeSpec.hs
+++ b/test/SynTreeSpec.hs
@@ -11,7 +11,14 @@ import TestHelpers (deleteSpaces)
 import Trees.Print (display)
 import Trees.Parsing (formulaParse)
 import Tasks.SynTree.Config (SynTreeConfig (..), SynTreeInst (..))
-import Trees.Helpers (collectLeaves, treeDepth, treeNodes, maxLeavesForNodes, maxNodesForDepth, minDepthForNodes, numOfUniqueBinOpsInSynTree)
+import Trees.Helpers (
+  collectLeaves,
+  treeDepth,
+  treeNodes,
+  maxLeavesForNodes,
+  maxNodesForDepth,
+  minDepthForNodes,
+  numOfUniqueBinOpsInSynTree)
 import Tasks.SynTree.Quiz (generateSynTreeInst)
 import Trees.Types (SynTree(..), BinOp(..))
 import Trees.Generate (genSynTree)
@@ -80,7 +87,8 @@ spec = do
         it "should return 1 if there are two operators of same kind" $
             numOfUniqueBinOpsInSynTree (Binary Or (Leaf 'a') (Not (Binary Or (Leaf 'a') (Leaf 'c')))) == 1
         it "should return 2 if there are two unique operators" $
-            numOfUniqueBinOpsInSynTree (Binary Or (Leaf 'a') (Not (Binary And (Leaf 'a') (Binary And (Leaf 'a') (Leaf 'c'))))) == 2
+            let subtree = Binary And (Leaf 'a') in
+            numOfUniqueBinOpsInSynTree (Binary Or (Leaf 'a') (Not (subtree (subtree (Leaf 'c'))))) == 2
   describe "genSynTree" $ do
     it "should generate a random SyntaxTree that satisfies the required amount of unique binary operators" $
       forAll validBoundsSynTree $ \SynTreeConfig {..} ->


### PR DESCRIPTION
Ich habe mich mal an der Umsetzung eines Filters hinsichtlich #65 probiert. Anhand des `minUniqueOperators` Wertes in `SuperfluousBracketsConfig` kann man eine Mindestanzahl an Operatoren festlegen. Ich habe zwei neue Testfälle erstellt, die soweit auch erfolgreich absolviert werden. 

Gibt es für mich auch eine Möglichkeit, lokal eine Aufgabe zu generieren und diese in der Konsole ausgeben zu lassen? 

Des Weiteren ist mir aufgefallen, dass `stack test` bei mir immer wieder mal bei unterschiedlichen Testfällen hängen bleibt (auch unabhängig von meinen Änderungen). Ist das ein Phänomen, das nur bei mir auftritt?

Hier ist ein Output von einem dieser Fälle:
```
logic-tasks> test (suite: src-test)


Formula
  genValidBoundsClause
    should generate valid bounds [✔]
      +++ OK, passed 100 tests.     
  genValidBoundsCnf
    should generate valid bounds [✔]
      +++ OK, passed 1000 tests.
  genLiteral
    should throw an error when called with the empty list [✔]
    should generate a random literal from the given char list [✔]     
      +++ OK, passed 100 tests; 19 discarded.
  genClause
    should return the empty Clause when called with the empty list [✔]
      +++ OK, passed 100 tests.
    should return the empty Clause when called with invalid boundaries [✔]
      +++ OK, passed 100 tests; 15 discarded.
    should generate a random clause of the correct length if given valid parameters [✔]
      +++ OK, passed 100 tests.
  genCnf
    should return the empty conjunction when called with the empty list [✔]
      +++ OK, passed 100 tests.
    should generate a random cnf formula with a correct amount of clauses if given valid parameters [✔]
      +++ OK, passed 100 tests.
    should generate a random cnf formula with the correct clause length if given valid parameters [✔]     
      +++ OK, passed 100 tests.
LegalCNF
  validBoundsLegalCNF
    produces a valid config [✔]
      +++ OK, passed 1000 tests.
  invalidBoundsLegalCNF
    produces a valid config [‐]
      # PENDING: No reason given
  genIllegalSynTree
    the syntax Tree are not CNF syntax tree [✔]     
      +++ OK, passed 100 tests.
  judgeCnfSynTree
    is reasonably implemented [✔]     
      +++ OK, passed 100 tests.
  generateLegalCNFInst
    all of the formulas in the wrong serial should not be Cnf [45/100]
```