### PR TITLE
Behebung von ungewünschter Formattierung in illegalen Formeln

### DIFF
--- a/src/Tasks/LegalProposition/PrintIllegal.hs
+++ b/src/Tasks/LegalProposition/PrintIllegal.hs
@@ -70,6 +70,8 @@ illegalShow notFirstLayer a b usedLiterals usedOperator =
 
 
 combineNormalShow :: SynTree BinOp Char -> SynTree BinOp Char -> String -> Bool -> Gen String
+combineNormalShow a b "" False = return (normalShow a ++ " " ++ normalShow b)
+combineNormalShow a b "" True = return ("(" ++ normalShow a ++ " " ++ normalShow b ++ ")")
 combineNormalShow a b replacedOperator False = return (normalShow a ++ " " ++ replacedOperator ++ " " ++ normalShow b)
 combineNormalShow a b replacedOperator True =
     return $ "(" ++ normalShow a ++ " " ++ replacedOperator ++ " " ++ normalShow b ++ ")"


### PR DESCRIPTION
Das Problem (bzgl. #63) lag in der Implementation von `combineNormalShow` mit `""` als Operator. Ursprünglich wurde vor und nach dem Operator ein Leerzeichen hinzugefügt. Da dies aber bei `""` als Operator ein Leerzeichen zu viel einfügt, habe ich Funktionsdefinition angepasst. Die Lücken sind dann wieder "normal" groß.