### PR TITLE
Resolution von Klauseln in "Prolog Notation" sollte nur Hornklauseln enthalten

### DIFF
--- a/logic-tasks.cabal
+++ b/logic-tasks.cabal
@@ -53,6 +53,7 @@ library
       Trees.Helpers
       Trees.Generate
       Formula.Parsing
+      Formula.Helpers
       ParsingHelpers
       Config
       Formula.Types
@@ -99,6 +100,7 @@ test-suite src-test
       LegalCNFSpec
       LegalPropositionSpec
       ParsingSpec
+      PrologSpec
       SubTreeSpec
       SuperfluousBracketsSpec
       SynTreeSpec

--- a/package.yaml
+++ b/package.yaml
@@ -69,6 +69,7 @@ library:
     - Trees.Helpers
     - Trees.Generate
     - Formula.Parsing
+    - Formula.Helpers
     - ParsingHelpers
     - Config
     - Formula.Types
@@ -80,7 +81,6 @@ library:
     - -Werror
     - -Wwarn=incomplete-uni-patterns
     - -fdefer-typed-holes
-
 
 tests:
   src-test:

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -272,6 +272,7 @@ data PrologConfig = PrologConfig {
     , maxClauseLength :: Int
     , usedPredicates :: [PrologLiteral]
     , extraText :: Maybe String
+    , createOnlyHornClauses :: Bool
     }
     deriving (Show, Typeable, Generic)
 
@@ -281,6 +282,7 @@ dPrologConf = PrologConfig
     , maxClauseLength = 3
     , usedPredicates = [PrologLiteral True "f" ["a"], PrologLiteral True "f" ["b"], PrologLiteral True "g" ["a"]]
     , extraText = Nothing
+    , createOnlyHornClauses = True
     }
 
 

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -272,7 +272,8 @@ data PrologConfig = PrologConfig {
     , maxClauseLength :: Int
     , usedPredicates :: [PrologLiteral]
     , extraText :: Maybe String
-    , createOnlyHornClauses :: Bool
+    , firstClauseShape :: ClauseShape
+    , secondClauseShape :: ClauseShape
     }
     deriving (Show, Typeable, Generic)
 
@@ -282,7 +283,8 @@ dPrologConf = PrologConfig
     , maxClauseLength = 3
     , usedPredicates = [PrologLiteral True "f" ["a"], PrologLiteral True "f" ["b"], PrologLiteral True "g" ["a"]]
     , extraText = Nothing
-    , createOnlyHornClauses = True
+    , firstClauseShape = HornClause Procedure
+    , secondClauseShape = HornClause Query
     }
 
 

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -283,8 +283,8 @@ dPrologConf = PrologConfig
     , maxClauseLength = 3
     , usedPredicates = [PrologLiteral True "f" ["a"], PrologLiteral True "f" ["b"], PrologLiteral True "g" ["a"]]
     , extraText = Nothing
-    , firstClauseShape = HornClause Procedure
-    , secondClauseShape = HornClause Query
+    , firstClauseShape = HornClause Query
+    , secondClauseShape = HornClause Procedure
     }
 
 

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -140,7 +140,7 @@ data PrologInst = PrologInst {
                , literals2 :: !PrologClause
                , addText :: !(Maybe String)
                }
-               deriving (Typeable, Generic)
+               deriving (Show, Typeable, Generic)
 
 
 dPrologInst :: PrologInst
@@ -273,7 +273,7 @@ data PrologConfig = PrologConfig {
     , usedPredicates :: [PrologLiteral]
     , extraText :: Maybe String
     }
-    deriving (Typeable, Generic)
+    deriving (Show, Typeable, Generic)
 
 dPrologConf :: PrologConfig
 dPrologConf = PrologConfig

--- a/src/Formula/Helpers.hs
+++ b/src/Formula/Helpers.hs
@@ -1,6 +1,14 @@
 {-# LANGUAGE RecordWildCards #-}
 module Formula.Helpers where
-import Formula.Types (PrologLiteral (..), PrologClause(..), terms)
+import Formula.Types (PrologLiteral (..), PrologClause(..), terms, ClauseShape(AnyClause, HornClause), HornShape (..))
 
-isHornClause :: PrologClause -> Bool
-isHornClause clause = length (filter (\PrologLiteral {..} -> polarity) (terms clause)) <= 1
+hasTheClauseShape :: ClauseShape -> PrologClause -> Bool
+hasTheClauseShape AnyClause _ = True
+hasTheClauseShape (HornClause hornShape) clause =
+  let positiveLiteralCount = length $ filter (\PrologLiteral {..} -> polarity) (terms clause)
+      negativeLiteralCount = length (terms clause) - positiveLiteralCount
+      in case hornShape of
+        AnyHornClause -> positiveLiteralCount <= 1
+        Fact -> positiveLiteralCount == 1 && negativeLiteralCount == 0
+        Procedure -> positiveLiteralCount == 1 && negativeLiteralCount > 0
+        Query -> positiveLiteralCount == 0 && negativeLiteralCount > 0

--- a/src/Formula/Helpers.hs
+++ b/src/Formula/Helpers.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE RecordWildCards #-}
+module Formula.Helpers where
+import Formula.Types (PrologLiteral (..), PrologClause(..), terms)
+
+isHornClause :: PrologClause -> Bool
+isHornClause clause = length (filter (\PrologLiteral {..} -> polarity) (terms clause)) <= 1

--- a/src/Formula/Types.hs
+++ b/src/Formula/Types.hs
@@ -29,6 +29,8 @@ module Formula.Types
        , PrologClause(..)
        , terms
        , lengthBound
+       , ClauseShape(..)
+       , HornShape(..)
        ) where
 
 
@@ -56,9 +58,8 @@ class Formula a where
     amount :: a -> Int
     evaluate :: Allocation -> a -> Maybe Bool
 
-
-
-
+data ClauseShape = AnyClause | HornClause HornShape deriving Show
+data HornShape = AnyHornClause | Fact | Procedure | Query deriving Show
 
 
 ---------------------------------------------------

--- a/src/Formula/Types.hs
+++ b/src/Formula/Types.hs
@@ -58,8 +58,8 @@ class Formula a where
     amount :: a -> Int
     evaluate :: Allocation -> a -> Maybe Bool
 
-data ClauseShape = AnyClause | HornClause HornShape deriving Show
-data HornShape = AnyHornClause | Fact | Procedure | Query deriving Show
+data ClauseShape = AnyClause | HornClause HornShape deriving (Show, Eq)
+data HornShape = AnyHornClause | Fact | Procedure | Query deriving (Show, Eq)
 
 
 ---------------------------------------------------

--- a/src/LogicTasks/Semantics/Prolog.hs
+++ b/src/LogicTasks/Semantics/Prolog.hs
@@ -24,7 +24,7 @@ import Formula.Util (flipPol, isEmptyClause, isPositive, mkPrologClause, transfo
 import Formula.Resolution (resolvable, resolve)
 import LogicTasks.Semantics.Step (genResStepClause)
 import Util(prevent, preventWithHint)
-import Formula.Helpers (isHornClause)
+import Formula.Helpers (hasTheClauseShape)
 
 
 genPrologInst :: PrologConfig -> Gen PrologInst
@@ -34,7 +34,7 @@ genPrologInst PrologConfig{..} = (do
       termAddedClause1 = mkPrologClause $ map remap (resolveLit : literals1)
       termAddedClause2 = mkPrologClause $ map remap (opposite resolveLit : literals clause)
     pure $ PrologInst termAddedClause1 termAddedClause2 extraText)
-  `suchThat` \(PrologInst clause1 clause2 _) -> not createOnlyHornClauses || (isHornClause clause1 && isHornClause clause2)
+  `suchThat` \(PrologInst clause1 clause2 _) -> hasTheClauseShape firstClauseShape clause1 && hasTheClauseShape secondClauseShape clause2
   where
     mapping = zip usedPredicates ['A'..'Z']
     usedLiterals = map snd mapping

--- a/src/LogicTasks/Semantics/Prolog.hs
+++ b/src/LogicTasks/Semantics/Prolog.hs
@@ -34,7 +34,7 @@ genPrologInst PrologConfig{..} = (do
       termAddedClause1 = mkPrologClause $ map remap (resolveLit : literals1)
       termAddedClause2 = mkPrologClause $ map remap (opposite resolveLit : literals clause)
     pure $ PrologInst termAddedClause1 termAddedClause2 extraText)
-  `suchThat` \(PrologInst clause1 clause2 _) -> isHornClause clause1 && isHornClause clause2
+  `suchThat` \(PrologInst clause1 clause2 _) -> not createOnlyHornClauses || (isHornClause clause1 && isHornClause clause2)
   where
     mapping = zip usedPredicates ['A'..'Z']
     usedLiterals = map snd mapping

--- a/src/LogicTasks/Semantics/Prolog.hs
+++ b/src/LogicTasks/Semantics/Prolog.hs
@@ -19,7 +19,7 @@ import Data.Tuple (swap)
 import Test.QuickCheck (Gen, suchThat)
 
 import Config (PrologConfig(..), PrologInst(..))
-import Formula.Types (Clause, Literal(..), PrologLiteral(..), PrologClause(..), literals, opposite)
+import Formula.Types (Clause, Literal(..), PrologLiteral(..), PrologClause(..), literals, opposite, ClauseShape (HornClause), HornShape (Fact, Query))
 import Formula.Util (flipPol, isEmptyClause, isPositive, mkPrologClause, transformProlog)
 import Formula.Resolution (resolvable, resolve)
 import LogicTasks.Semantics.Step (genResStepClause)
@@ -115,6 +115,11 @@ verifyQuiz PrologConfig{..}
         refuse $ indent $ translate $ do
           german "Es wurden keine Literale angegeben."
           english "You did not specify which literals should be used."
+
+    | (firstClauseShape `elem` [HornClause Fact, HornClause Query]) && firstClauseShape == secondClauseShape =
+        refuse $ indent $ translate $ do
+          german "Mit diesen Klauselformen ist keine Resolution möglich."
+          english "No resolution is possible with these clause forms."
 
     | otherwise = pure()
 

--- a/src/LogicTasks/Semantics/Prolog.hs
+++ b/src/LogicTasks/Semantics/Prolog.hs
@@ -16,7 +16,7 @@ import Control.Monad.Output (
 import Data.Maybe (fromJust, fromMaybe)
 import Data.Set (difference, member, toList, union)
 import Data.Tuple (swap)
-import Test.QuickCheck (Gen)
+import Test.QuickCheck (Gen, suchThat)
 
 import Config (PrologConfig(..), PrologInst(..))
 import Formula.Types (Clause, Literal(..), PrologLiteral(..), PrologClause(..), literals, opposite)
@@ -24,13 +24,14 @@ import Formula.Util (flipPol, isEmptyClause, isPositive, mkPrologClause, transfo
 import Formula.Resolution (resolvable, resolve)
 import LogicTasks.Semantics.Step (genResStepClause)
 import Util(prevent, preventWithHint)
-
-
+import Formula.Helpers (isHornClause)
 
 
 genPrologInst :: PrologConfig -> Gen PrologInst
 genPrologInst PrologConfig{..} = do
     (clause, resolveLit, literals1) <- genResStepClause minClauseLength maxClauseLength usedLiterals
+      `suchThat` \(clause', resolveLit', literals1') -> isHornClause (mkPrologClause $ map remap (resolveLit' : literals1')) &&
+                                                          isHornClause (mkPrologClause $ map remap (opposite resolveLit' : literals clause'))
     let
       termAddedClause1 = mkPrologClause $ map remap (resolveLit : literals1)
       termAddedClause2 = mkPrologClause $ map remap (opposite resolveLit : literals clause)

--- a/src/LogicTasks/Semantics/Prolog.hs
+++ b/src/LogicTasks/Semantics/Prolog.hs
@@ -28,14 +28,13 @@ import Formula.Helpers (isHornClause)
 
 
 genPrologInst :: PrologConfig -> Gen PrologInst
-genPrologInst PrologConfig{..} = do
+genPrologInst PrologConfig{..} = (do
     (clause, resolveLit, literals1) <- genResStepClause minClauseLength maxClauseLength usedLiterals
-      `suchThat` \(clause', resolveLit', literals1') -> isHornClause (mkPrologClause $ map remap (resolveLit' : literals1')) &&
-                                                          isHornClause (mkPrologClause $ map remap (opposite resolveLit' : literals clause'))
     let
       termAddedClause1 = mkPrologClause $ map remap (resolveLit : literals1)
       termAddedClause2 = mkPrologClause $ map remap (opposite resolveLit : literals clause)
-    pure $ PrologInst termAddedClause1 termAddedClause2 extraText
+    pure $ PrologInst termAddedClause1 termAddedClause2 extraText)
+  `suchThat` \(PrologInst clause1 clause2 _) -> isHornClause clause1 && isHornClause clause2
   where
     mapping = zip usedPredicates ['A'..'Z']
     usedLiterals = map snd mapping

--- a/test/PrologSpec.hs
+++ b/test/PrologSpec.hs
@@ -9,6 +9,6 @@ import Test.QuickCheck
 spec :: Spec
 spec = do
   describe "genPrologInst" $
-    it "should work" $
+    it "should only generate PrologInst with horn clauses" $
       forAll (genPrologInst dPrologConf) $ \PrologInst {..} ->
         isHornClause literals1 && isHornClause literals2

--- a/test/PrologSpec.hs
+++ b/test/PrologSpec.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE RecordWildCards #-}
+module PrologSpec where
+import Test.Hspec
+import LogicTasks.Semantics.Prolog (genPrologInst)
+import Config (dPrologConf, PrologInst (..))
+import Formula.Helpers (isHornClause)
+import Test.QuickCheck
+
+spec :: Spec
+spec = do
+  describe "genPrologInst" $
+    it "should work" $
+      forAll (genPrologInst dPrologConf) $ \PrologInst {..} ->
+        isHornClause literals1 && isHornClause literals2

--- a/test/PrologSpec.hs
+++ b/test/PrologSpec.hs
@@ -9,6 +9,6 @@ import Test.QuickCheck
 spec :: Spec
 spec = do
   describe "genPrologInst" $
-    it "should only generate PrologInst with horn clauses" $
+    it "should only generate PrologInst with horn clauses by default" $
       forAll (genPrologInst dPrologConf) $ \PrologInst {..} ->
         isHornClause literals1 && isHornClause literals2

--- a/test/PrologSpec.hs
+++ b/test/PrologSpec.hs
@@ -3,12 +3,13 @@ module PrologSpec where
 import Test.Hspec
 import LogicTasks.Semantics.Prolog (genPrologInst)
 import Config (dPrologConf, PrologInst (..))
-import Formula.Helpers (isHornClause)
+import Formula.Helpers (hasTheClauseShape)
 import Test.QuickCheck
+import LogicTasks.Config (PrologConfig (firstClauseShape, secondClauseShape))
 
 spec :: Spec
 spec = do
   describe "genPrologInst" $
     it "should only generate PrologInst with horn clauses by default" $
       forAll (genPrologInst dPrologConf) $ \PrologInst {..} ->
-        isHornClause literals1 && isHornClause literals2
+        hasTheClauseShape (firstClauseShape dPrologConf) literals1 && hasTheClauseShape (secondClauseShape dPrologConf) literals2

--- a/test/PrologSpec.hs
+++ b/test/PrologSpec.hs
@@ -12,4 +12,5 @@ spec = do
   describe "genPrologInst" $
     it "should only generate PrologInst with horn clauses by default" $
       forAll (genPrologInst dPrologConf) $ \PrologInst {..} ->
-        hasTheClauseShape (firstClauseShape dPrologConf) literals1 && hasTheClauseShape (secondClauseShape dPrologConf) literals2
+        hasTheClauseShape (firstClauseShape dPrologConf) literals1
+          && hasTheClauseShape (secondClauseShape dPrologConf) literals2


### PR DESCRIPTION
Behebt #54. `genPrologInst` generiert nun nur `PrologInst` mit Hornklauseln. Ich habe dementsprechend auch ein Testcase erstellt, welches erfolgreich durchlaufen wird.