### PR TITLE
Internationalisierung

### DIFF
--- a/src/Config.hs
+++ b/src/Config.hs
@@ -27,7 +27,7 @@ instance Show StepAnswer where
 data PickInst = PickInst {
                  cnfs    :: ![Cnf]
                , correct :: !Int
-               , extraText :: Maybe (Map Language String)
+               , addText :: Maybe (Map Language String)
                }
                deriving (Typeable, Generic)
 
@@ -35,21 +35,21 @@ dPickInst :: PickInst
 dPickInst =  PickInst
           { cnfs = [mkCnf [mkClause [Literal 'A', Not 'B']], mkCnf [mkClause [Not 'A', Literal 'B']]]
           , correct = 1
-          , extraText = Nothing
+          , addText = Nothing
           }
 
 
 
 data MaxInst = MaxInst {
                  cnf     :: !Cnf
-               , extraText :: Maybe (Map Language String)
+               , addText :: Maybe (Map Language String)
                }
                deriving (Typeable, Generic)
 
 dMaxInst :: MaxInst
 dMaxInst =  MaxInst
           { cnf = mkCnf [mkClause [Literal 'A', Not 'B']]
-          , extraText = Nothing
+          , addText = Nothing
           }
 
 
@@ -57,14 +57,14 @@ dMaxInst =  MaxInst
 
 data MinInst = MinInst {
                  dnf     :: !Dnf
-               , extraText :: Maybe (Map Language String)
+               , addText :: Maybe (Map Language String)
                }
                deriving (Typeable, Generic)
 
 dMinInst :: MinInst
 dMinInst =  MinInst
           { dnf = mkDnf [mkCon [Literal 'A', Not 'B']]
-          , extraText = Nothing
+          , addText = Nothing
           }
 
 
@@ -72,7 +72,7 @@ dMinInst =  MinInst
 data FillInst = FillInst {
                  cnf     :: !Cnf
                , missing :: ![Int]
-               , extraText :: Maybe (Map Language String)
+               , addText :: Maybe (Map Language String)
                }
                deriving (Typeable, Generic)
 
@@ -80,7 +80,7 @@ dFillInst :: FillInst
 dFillInst =  FillInst
           { cnf = mkCnf [mkClause [Literal 'A', Not 'B']]
           , missing = [1,4]
-          , extraText = Nothing
+          , addText = Nothing
           }
 
 
@@ -88,7 +88,7 @@ dFillInst =  FillInst
 data DecideInst = DecideInst {
                  cnf     :: !Cnf
                , changed :: ![Int]
-               , extraText :: Maybe (Map Language String)
+               , addText :: Maybe (Map Language String)
                }
                deriving (Typeable, Generic)
 
@@ -96,7 +96,7 @@ dDecideInst :: DecideInst
 dDecideInst =  DecideInst
           { cnf = mkCnf [mkClause [Literal 'A', Not 'B']]
           , changed = [1,4]
-          , extraText = Nothing
+          , addText = Nothing
           }
 
 
@@ -104,7 +104,7 @@ dDecideInst =  DecideInst
 data StepInst = StepInst {
                  clause1 :: !Clause
                , clause2 :: !Clause
-               , extraText :: Maybe (Map Language String)
+               , addText :: Maybe (Map Language String)
                }
                deriving (Typeable, Generic)
 
@@ -112,14 +112,14 @@ dStepInst :: StepInst
 dStepInst =  StepInst
           { clause1 = mkClause [Not 'A', Not 'C', Literal 'B']
           , clause2 = mkClause [Literal 'A', Not 'C']
-          , extraText = Nothing
+          , addText = Nothing
           }
 
 
 
 data ResolutionInst = ResolutionInst {
                  clauses :: ![Clause]
-               , extraText    :: Maybe (Map Language String)
+               , addText    :: Maybe (Map Language String)
                }
                deriving (Typeable, Generic)
 
@@ -131,7 +131,7 @@ dResInst =  ResolutionInst
               , mkClause [Literal 'C']
               , mkClause [Not 'B']
               ]
-          , extraText = Nothing
+          , addText = Nothing
           }
 
 
@@ -140,7 +140,7 @@ dResInst =  ResolutionInst
 data PrologInst = PrologInst {
                  literals1 :: !PrologClause
                , literals2 :: !PrologClause
-               , extraText :: Maybe (Map Language String)
+               , addText :: Maybe (Map Language String)
                }
                deriving (Typeable, Generic)
 
@@ -149,7 +149,7 @@ dPrologInst :: PrologInst
 dPrologInst =  PrologInst
           { literals1 = mkPrologClause [PrologLiteral True "pred" ["fact"]]
           , literals2 = mkPrologClause [PrologLiteral False "pred" ["fact"]]
-          , extraText = Nothing
+          , addText = Nothing
           }
 
 

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -8,6 +8,8 @@ import Data.Typeable
 import GHC.Generics
 import Formula.Types
 import Formula.Util
+import Data.Map (Map)
+import Control.Monad.Output (Language)
 
 
 
@@ -25,7 +27,7 @@ instance Show StepAnswer where
 data PickInst = PickInst {
                  cnfs    :: ![Cnf]
                , correct :: !Int
-               , addText :: !(Maybe String)
+               , extraText :: Maybe (Map Language String)
                }
                deriving (Typeable, Generic)
 
@@ -33,21 +35,21 @@ dPickInst :: PickInst
 dPickInst =  PickInst
           { cnfs = [mkCnf [mkClause [Literal 'A', Not 'B']], mkCnf [mkClause [Not 'A', Literal 'B']]]
           , correct = 1
-          , addText = Nothing
+          , extraText = Nothing
           }
 
 
 
 data MaxInst = MaxInst {
                  cnf     :: !Cnf
-               , addText :: !(Maybe String)
+               , extraText :: Maybe (Map Language String)
                }
                deriving (Typeable, Generic)
 
 dMaxInst :: MaxInst
 dMaxInst =  MaxInst
           { cnf = mkCnf [mkClause [Literal 'A', Not 'B']]
-          , addText = Nothing
+          , extraText = Nothing
           }
 
 
@@ -55,14 +57,14 @@ dMaxInst =  MaxInst
 
 data MinInst = MinInst {
                  dnf     :: !Dnf
-               , addText :: !(Maybe String)
+               , extraText :: Maybe (Map Language String)
                }
                deriving (Typeable, Generic)
 
 dMinInst :: MinInst
 dMinInst =  MinInst
           { dnf = mkDnf [mkCon [Literal 'A', Not 'B']]
-          , addText = Nothing
+          , extraText = Nothing
           }
 
 
@@ -70,7 +72,7 @@ dMinInst =  MinInst
 data FillInst = FillInst {
                  cnf     :: !Cnf
                , missing :: ![Int]
-               , addText :: !(Maybe String)
+               , extraText :: Maybe (Map Language String)
                }
                deriving (Typeable, Generic)
 
@@ -78,7 +80,7 @@ dFillInst :: FillInst
 dFillInst =  FillInst
           { cnf = mkCnf [mkClause [Literal 'A', Not 'B']]
           , missing = [1,4]
-          , addText = Nothing
+          , extraText = Nothing
           }
 
 
@@ -86,7 +88,7 @@ dFillInst =  FillInst
 data DecideInst = DecideInst {
                  cnf     :: !Cnf
                , changed :: ![Int]
-               , addText :: !(Maybe String)
+               , extraText :: Maybe (Map Language String)
                }
                deriving (Typeable, Generic)
 
@@ -94,7 +96,7 @@ dDecideInst :: DecideInst
 dDecideInst =  DecideInst
           { cnf = mkCnf [mkClause [Literal 'A', Not 'B']]
           , changed = [1,4]
-          , addText = Nothing
+          , extraText = Nothing
           }
 
 
@@ -102,7 +104,7 @@ dDecideInst =  DecideInst
 data StepInst = StepInst {
                  clause1 :: !Clause
                , clause2 :: !Clause
-               , addText :: !(Maybe String)
+               , extraText :: Maybe (Map Language String)
                }
                deriving (Typeable, Generic)
 
@@ -110,14 +112,14 @@ dStepInst :: StepInst
 dStepInst =  StepInst
           { clause1 = mkClause [Not 'A', Not 'C', Literal 'B']
           , clause2 = mkClause [Literal 'A', Not 'C']
-          , addText = Nothing
+          , extraText = Nothing
           }
 
 
 
 data ResolutionInst = ResolutionInst {
                  clauses :: ![Clause]
-               , addText    :: !(Maybe String)
+               , extraText    :: Maybe (Map Language String)
                }
                deriving (Typeable, Generic)
 
@@ -129,7 +131,7 @@ dResInst =  ResolutionInst
               , mkClause [Literal 'C']
               , mkClause [Not 'B']
               ]
-          , addText = Nothing
+          , extraText = Nothing
           }
 
 
@@ -138,7 +140,7 @@ dResInst =  ResolutionInst
 data PrologInst = PrologInst {
                  literals1 :: !PrologClause
                , literals2 :: !PrologClause
-               , addText :: !(Maybe String)
+               , extraText :: Maybe (Map Language String)
                }
                deriving (Typeable, Generic)
 
@@ -147,7 +149,7 @@ dPrologInst :: PrologInst
 dPrologInst =  PrologInst
           { literals1 = mkPrologClause [PrologLiteral True "pred" ["fact"]]
           , literals2 = mkPrologClause [PrologLiteral False "pred" ["fact"]]
-          , addText = Nothing
+          , extraText = Nothing
           }
 
 
@@ -189,7 +191,7 @@ data PickConfig = PickConfig {
        cnfConf :: CnfConfig
      , amountOfOptions :: Int
      , pickCnf :: Bool
-     , extraText :: Maybe String
+     , extraText :: Maybe (Map Language String)
      }
      deriving (Typeable, Generic)
 
@@ -207,7 +209,7 @@ data FillConfig = FillConfig {
       cnfConf :: CnfConfig
     , percentageOfGaps :: Int
     , percentTrueEntries :: Maybe (Int,Int)
-    , extraText :: Maybe String
+    , extraText :: Maybe (Map Language String)
     }
     deriving (Typeable, Generic)
 
@@ -224,7 +226,7 @@ dFillConf = FillConfig
 data MinMaxConfig = MinMaxConfig {
       cnfConf :: CnfConfig
     , percentTrueEntries :: Maybe (Int,Int)
-    , extraText :: Maybe String
+    , extraText :: Maybe (Map Language String)
     }
     deriving (Typeable, Generic)
 
@@ -240,7 +242,7 @@ dMinMaxConf = MinMaxConfig
 data DecideConfig = DecideConfig {
       cnfConf :: CnfConfig
     , percentageOfChanged :: Int
-    , extraText :: Maybe String
+    , extraText :: Maybe (Map Language String)
     }
     deriving (Typeable, Generic)
 
@@ -255,7 +257,7 @@ dDecideConf = DecideConfig
 
 data StepConfig = StepConfig {
       baseConf :: BaseConfig
-    , extraText :: Maybe String
+    , extraText :: Maybe (Map Language String)
     }
     deriving (Typeable, Generic)
 
@@ -271,7 +273,7 @@ data PrologConfig = PrologConfig {
       minClauseLength :: Int
     , maxClauseLength :: Int
     , usedPredicates :: [PrologLiteral]
-    , extraText :: Maybe String
+    , extraText :: Maybe (Map Language String)
     }
     deriving (Typeable, Generic)
 
@@ -287,7 +289,7 @@ dPrologConf = PrologConfig
 data ResolutionConfig = ResolutionConfig {
       baseConf :: BaseConfig
     , minSteps :: Int
-    , extraText :: Maybe String
+    , extraText :: Maybe (Map Language String)
     }
     deriving (Typeable, Generic)
 

--- a/src/Formula/Parsing.hs
+++ b/src/Formula/Parsing.hs
@@ -10,6 +10,7 @@ import Formula.Types
 
 import Control.Monad (void)
 import Data.Char (toLower)
+import Data.Map (fromList)
 import Text.ParserCombinators.Parsec (
   Parser,
   (<?>),
@@ -299,7 +300,7 @@ instance Parse PickInst where
         index <- lexeme $ many1 digit
         text <- optionMaybe $ lexeme bonusText
         char ')'
-        pure $ PickInst cs (read index) text
+        pure $ PickInst cs (read index) (fromList . read <$> text)
           where
             bonusText = between start (char '}') $ many1 $ satisfy ( /= '}')
             start = do

--- a/src/Formula/Printing.hs
+++ b/src/Formula/Printing.hs
@@ -144,7 +144,7 @@ instance Pretty PickInst where
       text "PickInst(" <> vcat
                            [ nest 2 $ pretty cnfs
                            , char ',' <+> pretty correct
-                           , maybe empty (\s -> myText (", {" ++ show (toList s) ++ "}")) extraText
+                           , maybe empty (\s -> myText (", {" ++ show (toList s) ++ "}")) addText
                            , char ')'
                            ]
 

--- a/src/Formula/Printing.hs
+++ b/src/Formula/Printing.hs
@@ -15,7 +15,7 @@ import Data.Text.Lazy (pack)
 import qualified Data.Set as Set (null)
 
 import Text.PrettyPrint.Leijen.Text
-
+import Data.Map (toList)
 
 
 
@@ -144,7 +144,7 @@ instance Pretty PickInst where
       text "PickInst(" <> vcat
                            [ nest 2 $ pretty cnfs
                            , char ',' <+> pretty correct
-                           , maybe empty (\s -> myText (", {" ++ s ++ "}")) addText
+                           , maybe empty (\s -> myText (", {" ++ show (toList s) ++ "}")) extraText
                            , char ')'
                            ]
 

--- a/src/LogicTasks/Helpers.hs
+++ b/src/LogicTasks/Helpers.hs
@@ -20,7 +20,7 @@ import Control.Monad.Output (
   translatedCode,
   localise,
   )
-import Control.Monad.State (State, MonadState (put))
+import Control.Monad.State (State, modify)
 import Data.Map (Map)
 import Data.ByteString.Lazy (fromStrict)
 import Data.ByteString.UTF8 (fromString)
@@ -30,7 +30,7 @@ import System.Directory (doesFileExist)
 
 
 extra :: OutputMonad m => Maybe (Map Language String) -> LangM m
-extra (Just extraMap) = paragraph $ translate $ put extraMap
+extra (Just extraMap) = paragraph $ translate $ modify (const extraMap)
 extra _ = pure ()
 
 indexed :: [String] -> [String]

--- a/src/LogicTasks/Helpers.hs
+++ b/src/LogicTasks/Helpers.hs
@@ -20,7 +20,7 @@ import Control.Monad.Output (
   translatedCode,
   localise,
   )
-import Control.Monad.State (State)
+import Control.Monad.State (State, MonadState (put))
 import Data.Map (Map)
 import Data.ByteString.Lazy (fromStrict)
 import Data.ByteString.UTF8 (fromString)
@@ -29,6 +29,9 @@ import System.Directory (doesFileExist)
 
 
 
+extra :: OutputMonad m => Maybe (Map Language String) -> LangM m
+extra (Just extraMap) = paragraph $ translate $ put extraMap
+extra _ = pure ()
 
 indexed :: [String] -> [String]
 indexed = zipWith (\a b -> show a ++ ". " ++ b) ([1..] :: [Int])

--- a/src/LogicTasks/Helpers.hs
+++ b/src/LogicTasks/Helpers.hs
@@ -20,7 +20,7 @@ import Control.Monad.Output (
   translatedCode,
   localise,
   )
-import Control.Monad.State (State, modify)
+import Control.Monad.State (State, put)
 import Data.Map (Map)
 import Data.ByteString.Lazy (fromStrict)
 import Data.ByteString.UTF8 (fromString)
@@ -30,7 +30,7 @@ import System.Directory (doesFileExist)
 
 
 extra :: OutputMonad m => Maybe (Map Language String) -> LangM m
-extra (Just extraMap) = paragraph $ translate $ modify (const extraMap)
+extra (Just extraMap) = paragraph $ translate $ put extraMap
 extra _ = pure ()
 
 indexed :: [String] -> [String]

--- a/src/LogicTasks/Semantics/Decide.hs
+++ b/src/LogicTasks/Semantics/Decide.hs
@@ -14,7 +14,6 @@ import Control.Monad.Output (
   translate,
   )
 import Data.List (nub)
-import Data.Maybe (fromMaybe)
 import Test.QuickCheck (Gen)
 
 import Config (BaseConfig(..), CnfConfig(..), DecideConfig(..), DecideInst(..))
@@ -22,6 +21,7 @@ import Formula.Util (isEmptyCnf, hasEmptyClause)
 import Formula.Table (flipAt, readEntries)
 import Formula.Types (atomics, availableLetter, genCnf, getTable, literals)
 import Util (checkCnfConf, isOutside, preventWithHint, remove)
+import LogicTasks.Helpers
 
 
 
@@ -63,7 +63,7 @@ description DecideInst{..} = do
       german "Ein Lösungsversuch könnte beispielsweise so aussehen: "
     code "[1,4,5]"
     pure ()
-  paragraph $ text (fromMaybe "" addText)
+  extra extraText
   pure ()
 
 

--- a/src/LogicTasks/Semantics/Decide.hs
+++ b/src/LogicTasks/Semantics/Decide.hs
@@ -63,7 +63,7 @@ description DecideInst{..} = do
       german "Ein Lösungsversuch könnte beispielsweise so aussehen: "
     code "[1,4,5]"
     pure ()
-  extra extraText
+  extra addText
   pure ()
 
 

--- a/src/LogicTasks/Semantics/Decide.hs
+++ b/src/LogicTasks/Semantics/Decide.hs
@@ -21,7 +21,7 @@ import Formula.Util (isEmptyCnf, hasEmptyClause)
 import Formula.Table (flipAt, readEntries)
 import Formula.Types (atomics, availableLetter, genCnf, getTable, literals)
 import Util (checkCnfConf, isOutside, preventWithHint, remove)
-import LogicTasks.Helpers
+import LogicTasks.Helpers (extra)
 
 
 

--- a/src/LogicTasks/Semantics/Fill.hs
+++ b/src/LogicTasks/Semantics/Fill.hs
@@ -69,7 +69,7 @@ description FillInst{..} = do
     code "[0,1,1,1]"
     pure ()
 
-  extra extraText
+  extra addText
   pure ()
 
 

--- a/src/LogicTasks/Semantics/Fill.hs
+++ b/src/LogicTasks/Semantics/Fill.hs
@@ -21,6 +21,7 @@ import Formula.Util (hasEmptyClause, isEmptyCnf)
 import Formula.Table (gapsAt, readEntries)
 import Formula.Types (TruthValue, availableLetter, atomics, genCnf, getTable, literals, truth)
 import Util (checkTruthValueRange, isOutside, pairwiseCheck, preventWithHint, remove, tryGen, withRatio)
+import LogicTasks.Helpers
 
 
 
@@ -67,7 +68,8 @@ description FillInst{..} = do
       english "A valid solution for four blanks could look like this:"
     code "[0,1,1,1]"
     pure ()
-  paragraph $ text (fromMaybe "" addText)
+
+  extra extraText
   pure ()
 
 

--- a/src/LogicTasks/Semantics/Fill.hs
+++ b/src/LogicTasks/Semantics/Fill.hs
@@ -21,7 +21,7 @@ import Formula.Util (hasEmptyClause, isEmptyCnf)
 import Formula.Table (gapsAt, readEntries)
 import Formula.Types (TruthValue, availableLetter, atomics, genCnf, getTable, literals, truth)
 import Util (checkTruthValueRange, isOutside, pairwiseCheck, preventWithHint, remove, tryGen, withRatio)
-import LogicTasks.Helpers
+import LogicTasks.Helpers (extra)
 
 
 

--- a/src/LogicTasks/Semantics/Max.hs
+++ b/src/LogicTasks/Semantics/Max.hs
@@ -23,8 +23,8 @@ import Config (BaseConfig(..), CnfConfig(..),  MaxInst(..), MinMaxConfig(..))
 import Formula.Util (hasEmptyClause, isEmptyCnf, mkClause, mkCnf)
 import Formula.Table (readEntries)
 import Formula.Types (Cnf, Formula, Literal(..), amount, atomics, genCnf, getClauses, getTable)
+import LogicTasks.Helpers (extra, formulaKey)
 import Util (checkTruthValueRange, pairwiseCheck, prevent, preventWithHint, tryGen, withRatio)
-import LogicTasks.Helpers (extra)
 
 
 

--- a/src/LogicTasks/Semantics/Max.hs
+++ b/src/LogicTasks/Semantics/Max.hs
@@ -23,8 +23,8 @@ import Config (BaseConfig(..), CnfConfig(..),  MaxInst(..), MinMaxConfig(..))
 import Formula.Util (hasEmptyClause, isEmptyCnf, mkClause, mkCnf)
 import Formula.Table (readEntries)
 import Formula.Types (Cnf, Formula, Literal(..), amount, atomics, genCnf, getClauses, getTable)
-import LogicTasks.Helpers (formulaKey)
 import Util (checkTruthValueRange, pairwiseCheck, prevent, preventWithHint, tryGen, withRatio)
+import LogicTasks.Helpers
 
 
 
@@ -61,7 +61,7 @@ description MaxInst{..} = do
       german "(A oder nicht B) und (nicht C oder nicht D)"
       english "(A or not B) and (not C or not D)"
     pure ()
-  paragraph $ text (fromMaybe "" addText)
+  extra extraText
   pure ()
 
 
@@ -90,7 +90,7 @@ start = mkCnf [mkClause [Literal 'A']]
 
 partialMinMax :: (OutputMonad m, Formula f) => [Literal] -> f -> f -> Bool -> Bool -> LangM m
 partialMinMax correctLits correct solution allValidTerms isMaxTermTask = do
-  preventWithHint (not $ null extra)
+  preventWithHint (not $ null extraLiterals)
     (translate $ do
       german "Angegebene Literale kommen in Aufgabe vor?"
       english "Given literals are used in task?"
@@ -100,7 +100,7 @@ partialMinMax correctLits correct solution allValidTerms isMaxTermTask = do
       translate $ do
         german "Es sind unbekannte Literale enthalten. Diese Literale kommen in der korrekten Lösung nicht vor: "
         english "Your submission contains unknown literals. These do not appear in a correct solution: "
-      itemizeM $ map (text . show) extra
+      itemizeM $ map (text . show) extraLiterals
       pure ()
     )
 
@@ -156,7 +156,7 @@ partialMinMax correctLits correct solution allValidTerms isMaxTermTask = do
   pure ()
  where
     solLits = atomics solution
-    extra = solLits \\ correctLits
+    extraLiterals = solLits \\ correctLits
     missing = correctLits \\ solLits
     table = getTable correct
     corrLen = length $ filter (== Just False) (readEntries table)

--- a/src/LogicTasks/Semantics/Max.hs
+++ b/src/LogicTasks/Semantics/Max.hs
@@ -24,7 +24,7 @@ import Formula.Util (hasEmptyClause, isEmptyCnf, mkClause, mkCnf)
 import Formula.Table (readEntries)
 import Formula.Types (Cnf, Formula, Literal(..), amount, atomics, genCnf, getClauses, getTable)
 import Util (checkTruthValueRange, pairwiseCheck, prevent, preventWithHint, tryGen, withRatio)
-import LogicTasks.Helpers
+import LogicTasks.Helpers (extra)
 
 
 

--- a/src/LogicTasks/Semantics/Max.hs
+++ b/src/LogicTasks/Semantics/Max.hs
@@ -61,7 +61,7 @@ description MaxInst{..} = do
       german "(A oder nicht B) und (nicht C oder nicht D)"
       english "(A or not B) and (not C or not D)"
     pure ()
-  extra extraText
+  extra addText
   pure ()
 
 

--- a/src/LogicTasks/Semantics/Min.hs
+++ b/src/LogicTasks/Semantics/Min.hs
@@ -23,7 +23,7 @@ import Test.QuickCheck (Gen)
 import Config (BaseConfig(..), CnfConfig(..), MinMaxConfig(..), MinInst(..))
 import Formula.Types (Dnf, Literal(..), amount, atomics, genDnf, getConjunctions, getTable)
 import Formula.Util (mkCon, mkDnf, hasEmptyCon, isEmptyDnf)
-import LogicTasks.Helpers
+import LogicTasks.Helpers (extra, formulaKey)
 import Util (tryGen, withRatio)
 
 

--- a/src/LogicTasks/Semantics/Min.hs
+++ b/src/LogicTasks/Semantics/Min.hs
@@ -23,7 +23,7 @@ import Test.QuickCheck (Gen)
 import Config (BaseConfig(..), CnfConfig(..), MinMaxConfig(..), MinInst(..))
 import Formula.Types (Dnf, Literal(..), amount, atomics, genDnf, getConjunctions, getTable)
 import Formula.Util (mkCon, mkDnf, hasEmptyCon, isEmptyDnf)
-import LogicTasks.Helpers (formulaKey)
+import LogicTasks.Helpers
 import Util (tryGen, withRatio)
 
 
@@ -61,7 +61,7 @@ description MinInst{..} = do
       german "(A und nicht B) oder (nicht C und nicht D)"
       english "(A and not B) or (not C and not D)"
     pure ()
-  paragraph $ text (fromMaybe "" addText)
+  extra extraText
   pure ()
 
 

--- a/src/LogicTasks/Semantics/Min.hs
+++ b/src/LogicTasks/Semantics/Min.hs
@@ -61,7 +61,7 @@ description MinInst{..} = do
       german "(A und nicht B) oder (nicht C und nicht D)"
       english "(A and not B) or (not C and not D)"
     pure ()
-  extra extraText
+  extra addText
   pure ()
 
 

--- a/src/LogicTasks/Semantics/Pick.hs
+++ b/src/LogicTasks/Semantics/Pick.hs
@@ -21,7 +21,7 @@ import Formula.Util (mkCnf, xorSat)
 import Formula.Types (atomics, availableLetter, genCnf, getTable, letter, literals)
 import Formula.Printing (showIndexedList)
 import Util (checkCnfConf, tryGen)
-import LogicTasks.Helpers
+import LogicTasks.Helpers (extra)
 
 
 

--- a/src/LogicTasks/Semantics/Pick.hs
+++ b/src/LogicTasks/Semantics/Pick.hs
@@ -62,7 +62,7 @@ description PickInst{..} = do
         english "A valid solution could look like this: "
       code "1"
       pure ()
-    extra extraText
+    extra addText
     pure ()
   where
     sTable = cnfs !! (correct - 1)

--- a/src/LogicTasks/Semantics/Pick.hs
+++ b/src/LogicTasks/Semantics/Pick.hs
@@ -13,7 +13,7 @@ import Control.Monad.Output (
   german,
   translate,
   )
-import Data.Maybe (fromMaybe)
+
 import Test.QuickCheck (Gen, elements, vectorOf)
 
 import Config (BaseConfig(..), CnfConfig(..), Number(..), PickConfig(..), PickInst(..))
@@ -21,6 +21,7 @@ import Formula.Util (mkCnf, xorSat)
 import Formula.Types (atomics, availableLetter, genCnf, getTable, letter, literals)
 import Formula.Printing (showIndexedList)
 import Util (checkCnfConf, tryGen)
+import LogicTasks.Helpers
 
 
 
@@ -61,7 +62,7 @@ description PickInst{..} = do
         english "A valid solution could look like this: "
       code "1"
       pure ()
-    paragraph $ text (fromMaybe "" addText)
+    extra extraText
     pure ()
   where
     sTable = cnfs !! (correct - 1)

--- a/src/LogicTasks/Semantics/Prolog.hs
+++ b/src/LogicTasks/Semantics/Prolog.hs
@@ -73,7 +73,7 @@ description PrologInst{..} = do
       english "A valid solution with the clauses a(x) and not(a(x)) could look like this:"
     code "(a(x), { })"
     pure ()
-  extra extraText
+  extra addText
   pure ()
 
 

--- a/src/LogicTasks/Semantics/Prolog.hs
+++ b/src/LogicTasks/Semantics/Prolog.hs
@@ -13,7 +13,7 @@ import Control.Monad.Output (
   german,
   translate,
   )
-import Data.Maybe (fromJust, fromMaybe)
+import Data.Maybe (fromJust)
 import Data.Set (difference, member, toList, union)
 import Data.Tuple (swap)
 import Test.QuickCheck (Gen)
@@ -24,6 +24,7 @@ import Formula.Util (flipPol, isEmptyClause, isPositive, mkPrologClause, transfo
 import Formula.Resolution (resolvable, resolve)
 import LogicTasks.Semantics.Step (genResStepClause)
 import Util(prevent, preventWithHint)
+import LogicTasks.Helpers
 
 
 
@@ -72,7 +73,7 @@ description PrologInst{..} = do
       english "A valid solution with the clauses a(x) and not(a(x)) could look like this:"
     code "(a(x), { })"
     pure ()
-  paragraph $ text (fromMaybe "" addText)
+  extra extraText
   pure ()
 
 
@@ -132,7 +133,7 @@ partialGrade PrologInst{..} sol = do
       german "Gewähltes Literal kommt in den Klauseln vor?"
       english "Chosen literal is contained in any of the clauses?"
 
-  preventWithHint (not $ null extra)
+  preventWithHint (not $ null extraLiterals)
     (translate $ do
        german "Resolvente besteht aus bekannten Literalen?"
        english "Resolvent contains only known literals?"
@@ -141,14 +142,14 @@ partialGrade PrologInst{..} sol = do
       translate $ do
         german "In der Resolvente sind unbekannte Literale enthalten. Diese Literale sind falsch: "
         english "The resolvent contains unknown literals. These are incorrect:"
-      itemizeM $ map (text . show) extra
+      itemizeM $ map (text . show) extraLiterals
       pure ()
     )
   pure ()
   where
      availLits = pLiterals literals1 `union` pLiterals literals2
      solLits = pLiterals $ snd sol
-     extra = toList $ solLits `difference` availLits
+     extraLiterals = toList $ solLits `difference` availLits
 
 
 

--- a/src/LogicTasks/Semantics/Resolve.hs
+++ b/src/LogicTasks/Semantics/Resolve.hs
@@ -24,8 +24,9 @@ import Config (ResolutionConfig(..), ResolutionInst(..), BaseConfig(..))
 import Formula.Util (isEmptyClause, mkCnf, sat)
 import Formula.Resolution (applySteps, genRes, resolvableWith, resolve)
 import Formula.Types (Clause, ResStep(..), literals)
+import LogicTasks.Helpers (clauseKey, extra)
 import Util (checkBaseConf, prevent, preventWithHint)
-import LogicTasks.Helpers
+
 
 
 

--- a/src/LogicTasks/Semantics/Resolve.hs
+++ b/src/LogicTasks/Semantics/Resolve.hs
@@ -93,7 +93,7 @@ description ResolutionInst{..} = do
       english "[(1, 2, {A, not B} = 5), (4, 5, { })]"
       german "[(1, 2, {A, nicht B} = 5), (4, 5, { })]"
     pure ()
-  extra extraText
+  extra addText
   pure ()
 
 

--- a/src/LogicTasks/Semantics/Resolve.hs
+++ b/src/LogicTasks/Semantics/Resolve.hs
@@ -17,16 +17,15 @@ import Control.Monad.Output (
   localise,
   )
 import Data.List (sort)
-import Data.Maybe (fromJust, fromMaybe)
+import Data.Maybe (fromJust)
 import Test.QuickCheck (Gen)
 
 import Config (ResolutionConfig(..), ResolutionInst(..), BaseConfig(..))
 import Formula.Util (isEmptyClause, mkCnf, sat)
 import Formula.Resolution (applySteps, genRes, resolvableWith, resolve)
 import Formula.Types (Clause, ResStep(..), literals)
-import LogicTasks.Helpers (clauseKey)
 import Util (checkBaseConf, prevent, preventWithHint)
-
+import LogicTasks.Helpers
 
 
 
@@ -94,7 +93,7 @@ description ResolutionInst{..} = do
       english "[(1, 2, {A, not B} = 5), (4, 5, { })]"
       german "[(1, 2, {A, nicht B} = 5), (4, 5, { })]"
     pure ()
-  paragraph $ text (fromMaybe "" addText)
+  extra extraText
   pure ()
 
 

--- a/src/LogicTasks/Semantics/Step.hs
+++ b/src/LogicTasks/Semantics/Step.hs
@@ -22,7 +22,7 @@ import Config (StepAnswer(..), StepConfig(..), StepInst(..), BaseConfig(..))
 import Formula.Util (isEmptyClause, mkClause)
 import Formula.Types (Clause, Literal(..), genClause, literals, opposite)
 import Formula.Resolution (resolvable, resolve)
-import LogicTasks.Helpers as LogicHelpers (clauseKey, extra)
+import LogicTasks.Helpers (clauseKey, extra)
 import Util (checkBaseConf, prevent, preventWithHint, tryGen)
 
 
@@ -63,7 +63,7 @@ description StepInst{..} = do
       english "A valid solution could look like this: "
     code "(A, not B or C)"
     pure ()
-  LogicHelpers.extra addText
+  extra addText
   pure ()
 
 

--- a/src/LogicTasks/Semantics/Step.hs
+++ b/src/LogicTasks/Semantics/Step.hs
@@ -63,7 +63,7 @@ description StepInst{..} = do
       english "A valid solution could look like this: "
     code "(A, not B or C)"
     pure ()
-  LogicHelpers.extra extraText
+  LogicHelpers.extra addText
   pure ()
 
 

--- a/src/LogicTasks/Semantics/Step.hs
+++ b/src/LogicTasks/Semantics/Step.hs
@@ -13,7 +13,7 @@ import Control.Monad.Output (
   german,
   translate,
   )
-import Data.Maybe (fromJust, fromMaybe, isNothing)
+import Data.Maybe (fromJust, isNothing)
 import Data.List (delete)
 import Data.Set (difference, fromList, member, toList, union)
 import Test.QuickCheck (Gen, elements)
@@ -22,7 +22,7 @@ import Config (StepAnswer(..), StepConfig(..), StepInst(..), BaseConfig(..))
 import Formula.Util (isEmptyClause, mkClause)
 import Formula.Types (Clause, Literal(..), genClause, literals, opposite)
 import Formula.Resolution (resolvable, resolve)
-import LogicTasks.Helpers (clauseKey)
+import LogicTasks.Helpers as LogicHelpers
 import Util (checkBaseConf, prevent, preventWithHint, tryGen)
 
 
@@ -63,7 +63,7 @@ description StepInst{..} = do
       english "A valid solution could look like this: "
     code "(A, not B or C)"
     pure ()
-  paragraph $ text (fromMaybe "" addText)
+  LogicHelpers.extra extraText
   pure ()
 
 
@@ -106,7 +106,7 @@ partialGrade StepInst{..} sol = do
       german "Das gewählte Literal kommt in einer der Klauseln vor?"
       english "The chosen literal is contained in any of the clauses?"
 
-  preventWithHint (not $ null extra)
+  preventWithHint (not $ null extraLiterals)
     (translate $ do
       german "Resolvente besteht aus bekannten Literalen?"
       english "Resolvent contains only known literals?"
@@ -115,7 +115,7 @@ partialGrade StepInst{..} sol = do
       translate $ do
         german "In der Resolvente sind unbekannte Literale enthalten. Diese Literale sind falsch: "
         english "The resolvent contains unknown literals. These literals are incorrect:"
-      itemizeM $ map (text . show) extra
+      itemizeM $ map (text . show) extraLiterals
       pure ()
     )
   pure ()
@@ -123,7 +123,7 @@ partialGrade StepInst{..} sol = do
      mSol = fromJust $ step sol
      availLits = fromList (literals clause1) `union` fromList (literals clause2)
      solLits = fromList $ literals $ snd mSol
-     extra = toList (solLits `difference` availLits)
+     extraLiterals = toList (solLits `difference` availLits)
 
 
 

--- a/src/LogicTasks/Semantics/Step.hs
+++ b/src/LogicTasks/Semantics/Step.hs
@@ -22,7 +22,7 @@ import Config (StepAnswer(..), StepConfig(..), StepInst(..), BaseConfig(..))
 import Formula.Util (isEmptyClause, mkClause)
 import Formula.Types (Clause, Literal(..), genClause, literals, opposite)
 import Formula.Resolution (resolvable, resolve)
-import LogicTasks.Helpers as LogicHelpers
+import LogicTasks.Helpers as LogicHelpers (clauseKey, extra)
 import Util (checkBaseConf, prevent, preventWithHint, tryGen)
 
 

--- a/src/LogicTasks/Syntax/IllegalCnfs.hs
+++ b/src/LogicTasks/Syntax/IllegalCnfs.hs
@@ -34,7 +34,7 @@ description LegalCNFInst{..} = do
       english "For example, if only choices 2 and 3 are non-cnf formulae, then the solution is:"
       german "Liegen beispielsweise nur Auswahlmöglichkeiten 2 und 3 nicht in KNF vor, dann ist diese Lösung korrekt:"
 
-    extra extraText
+    extra addText
 
     pure ()
 

--- a/src/LogicTasks/Syntax/IllegalCnfs.hs
+++ b/src/LogicTasks/Syntax/IllegalCnfs.hs
@@ -8,7 +8,7 @@ import Control.Monad.Output (LangM, OutputMonad, english, german)
 import Data.List (nub, sort)
 import Data.Set (toList)
 
-import LogicTasks.Helpers (example, extra, focus, instruct, reject)
+import LogicTasks.Helpers (example, extra, focus, indexed, instruct, reject)
 import Tasks.LegalCNF.Config(LegalCNFConfig(..), LegalCNFInst(..), checkLegalCNFConfig)
 
 

--- a/src/LogicTasks/Syntax/IllegalCnfs.hs
+++ b/src/LogicTasks/Syntax/IllegalCnfs.hs
@@ -4,10 +4,9 @@
 module LogicTasks.Syntax.IllegalCnfs where
 
 
-import Control.Monad.Output (LangM, OutputMonad, english, german, paragraph, text)
+import Control.Monad.Output (LangM, OutputMonad, english, german)
 import Data.List (nub, sort)
 import Data.Set (toList)
-import Data.Maybe (fromMaybe)
 
 import LogicTasks.Helpers
 import Tasks.LegalCNF.Config(LegalCNFConfig(..), LegalCNFInst(..), checkLegalCNFConfig)
@@ -35,7 +34,8 @@ description LegalCNFInst{..} = do
       english "For example, if only choices 2 and 3 are non-cnf formulae, then the solution is:"
       german "Liegen beispielsweise nur Auswahlmöglichkeiten 2 und 3 nicht in KNF vor, dann ist diese Lösung korrekt:"
 
-    paragraph $ text (fromMaybe "" extraText)
+    extra extraText
+
     pure ()
 
 

--- a/src/LogicTasks/Syntax/IllegalCnfs.hs
+++ b/src/LogicTasks/Syntax/IllegalCnfs.hs
@@ -8,7 +8,7 @@ import Control.Monad.Output (LangM, OutputMonad, english, german)
 import Data.List (nub, sort)
 import Data.Set (toList)
 
-import LogicTasks.Helpers
+import LogicTasks.Helpers (extra)
 import Tasks.LegalCNF.Config(LegalCNFConfig(..), LegalCNFInst(..), checkLegalCNFConfig)
 
 

--- a/src/LogicTasks/Syntax/IllegalCnfs.hs
+++ b/src/LogicTasks/Syntax/IllegalCnfs.hs
@@ -8,7 +8,7 @@ import Control.Monad.Output (LangM, OutputMonad, english, german)
 import Data.List (nub, sort)
 import Data.Set (toList)
 
-import LogicTasks.Helpers (extra)
+import LogicTasks.Helpers (example, extra, focus, instruct, reject)
 import Tasks.LegalCNF.Config(LegalCNFConfig(..), LegalCNFInst(..), checkLegalCNFConfig)
 
 

--- a/src/LogicTasks/Syntax/IllegalFormulas.hs
+++ b/src/LogicTasks/Syntax/IllegalFormulas.hs
@@ -5,10 +5,9 @@
 module LogicTasks.Syntax.IllegalFormulas where
 
 
-import Control.Monad.Output (LangM, OutputMonad, english, german, paragraph, text)
+import Control.Monad.Output (LangM, OutputMonad, english, german)
 import Data.List (nub, sort)
 import Data.Set (toList)
-import Data.Maybe (fromMaybe)
 
 import LogicTasks.Helpers
 import Tasks.LegalProposition.Config (LegalPropositionInst(..), LegalPropositionConfig(..), checkLegalPropositionConfig)
@@ -36,7 +35,7 @@ description LegalPropositionInst{..} = do
       english "For example, if only choices 2 and 3 are incorrect, then the solution is:"
       german "Sind beispielsweise nur Auswahlmöglichkeiten 2 und 3 falsch, dann ist diese Lösung korrekt:"
 
-    paragraph $ text (fromMaybe "" extraText)
+    extra extraText
     pure ()
 
 

--- a/src/LogicTasks/Syntax/IllegalFormulas.hs
+++ b/src/LogicTasks/Syntax/IllegalFormulas.hs
@@ -9,7 +9,7 @@ import Control.Monad.Output (LangM, OutputMonad, english, german)
 import Data.List (nub, sort)
 import Data.Set (toList)
 
-import LogicTasks.Helpers
+import LogicTasks.Helpers (extra)
 import Tasks.LegalProposition.Config (LegalPropositionInst(..), LegalPropositionConfig(..), checkLegalPropositionConfig)
 
 

--- a/src/LogicTasks/Syntax/IllegalFormulas.hs
+++ b/src/LogicTasks/Syntax/IllegalFormulas.hs
@@ -35,7 +35,7 @@ description LegalPropositionInst{..} = do
       english "For example, if only choices 2 and 3 are incorrect, then the solution is:"
       german "Sind beispielsweise nur Auswahlmöglichkeiten 2 und 3 falsch, dann ist diese Lösung korrekt:"
 
-    extra extraText
+    extra addText
     pure ()
 
 

--- a/src/LogicTasks/Syntax/IllegalFormulas.hs
+++ b/src/LogicTasks/Syntax/IllegalFormulas.hs
@@ -9,7 +9,7 @@ import Control.Monad.Output (LangM, OutputMonad, english, german)
 import Data.List (nub, sort)
 import Data.Set (toList)
 
-import LogicTasks.Helpers (extra)
+import LogicTasks.Helpers (extra, instruct, indexed, focus, reject)
 import Tasks.LegalProposition.Config (LegalPropositionInst(..), LegalPropositionConfig(..), checkLegalPropositionConfig)
 
 

--- a/src/LogicTasks/Syntax/IllegalFormulas.hs
+++ b/src/LogicTasks/Syntax/IllegalFormulas.hs
@@ -9,7 +9,7 @@ import Control.Monad.Output (LangM, OutputMonad, english, german)
 import Data.List (nub, sort)
 import Data.Set (toList)
 
-import LogicTasks.Helpers (extra, instruct, indexed, focus, reject)
+import LogicTasks.Helpers (example, extra, focus, indexed, instruct, reject)
 import Tasks.LegalProposition.Config (LegalPropositionInst(..), LegalPropositionConfig(..), checkLegalPropositionConfig)
 
 

--- a/src/LogicTasks/Syntax/SimplestFormula.hs
+++ b/src/LogicTasks/Syntax/SimplestFormula.hs
@@ -9,7 +9,7 @@ import Control.Monad.Output (LangM, OutputMonad, english, german, paragraph, tra
 import Data.List (nub, sort)
 import Data.Maybe (isNothing, fromJust)
 
-import LogicTasks.Helpers
+import LogicTasks.Helpers (extra)
 import Tasks.SuperfluousBrackets.Config (
     checkSuperfluousBracketsConfig,
     SuperfluousBracketsConfig(..),

--- a/src/LogicTasks/Syntax/SimplestFormula.hs
+++ b/src/LogicTasks/Syntax/SimplestFormula.hs
@@ -54,7 +54,7 @@ description SuperfluousBracketsInst{..} = do
       english "You can copy the original formula into the solution box and remove unnecessary brackets or use the following syntax:"
     basicOpKey
 
-    extra extraText
+    extra addText
     pure ()
 
 

--- a/src/LogicTasks/Syntax/SimplestFormula.hs
+++ b/src/LogicTasks/Syntax/SimplestFormula.hs
@@ -9,7 +9,7 @@ import Control.Monad.Output (LangM, OutputMonad, english, german, paragraph, tra
 import Data.List (nub, sort)
 import Data.Maybe (isNothing, fromJust)
 
-import LogicTasks.Helpers (extra)
+import LogicTasks.Helpers (basicOpKey, example, extra, focus, instruct, reject)
 import Tasks.SuperfluousBrackets.Config (
     checkSuperfluousBracketsConfig,
     SuperfluousBracketsConfig(..),

--- a/src/LogicTasks/Syntax/SimplestFormula.hs
+++ b/src/LogicTasks/Syntax/SimplestFormula.hs
@@ -5,9 +5,9 @@
 module LogicTasks.Syntax.SimplestFormula where
 
 
-import Control.Monad.Output (LangM, OutputMonad, english, german, paragraph, translate, text)
+import Control.Monad.Output (LangM, OutputMonad, english, german, paragraph, translate)
 import Data.List (nub, sort)
-import Data.Maybe (isNothing, fromJust, fromMaybe)
+import Data.Maybe (isNothing, fromJust)
 
 import LogicTasks.Helpers
 import Tasks.SuperfluousBrackets.Config (
@@ -54,7 +54,7 @@ description SuperfluousBracketsInst{..} = do
       english "You can copy the original formula into the solution box and remove unnecessary brackets or use the following syntax:"
     basicOpKey
 
-    paragraph $ text (fromMaybe "" extraText)
+    extra extraText
     pure ()
 
 

--- a/src/LogicTasks/Syntax/SubTreeSet.hs
+++ b/src/LogicTasks/Syntax/SubTreeSet.hs
@@ -44,7 +44,7 @@ description SubTreeInst{..} = do
     keyHeading
     fullKey
 
-    extra extraText
+    extra addText
     pure ()
 
 

--- a/src/LogicTasks/Syntax/SubTreeSet.hs
+++ b/src/LogicTasks/Syntax/SubTreeSet.hs
@@ -10,7 +10,7 @@ import Data.List (nub, sort)
 import Data.Set (fromList, isSubsetOf)
 import Data.Maybe (isNothing, fromJust)
 
-import LogicTasks.Helpers (extra)
+import LogicTasks.Helpers (example, extra, focus, fullKey, instruct, keyHeading, reject)
 import Tasks.SubTree.Config (checkSubTreeConfig, SubTreeInst(..), SubTreeConfig(..))
 import Trees.Types (FormulaAnswer(..))
 import Trees.Print (display)

--- a/src/LogicTasks/Syntax/SubTreeSet.hs
+++ b/src/LogicTasks/Syntax/SubTreeSet.hs
@@ -5,10 +5,10 @@
 module LogicTasks.Syntax.SubTreeSet where
 
 
-import Control.Monad.Output (LangM, OutputMonad, english, german, paragraph, text)
+import Control.Monad.Output (LangM, OutputMonad, english, german)
 import Data.List (nub, sort)
 import Data.Set (fromList, isSubsetOf)
-import Data.Maybe (isNothing, fromJust, fromMaybe)
+import Data.Maybe (isNothing, fromJust)
 
 import LogicTasks.Helpers
 import Tasks.SubTree.Config (checkSubTreeConfig, SubTreeInst(..), SubTreeConfig(..))
@@ -44,7 +44,7 @@ description SubTreeInst{..} = do
     keyHeading
     fullKey
 
-    paragraph $ text (fromMaybe "" extraText)
+    extra extraText
     pure ()
 
 

--- a/src/LogicTasks/Syntax/SubTreeSet.hs
+++ b/src/LogicTasks/Syntax/SubTreeSet.hs
@@ -10,7 +10,7 @@ import Data.List (nub, sort)
 import Data.Set (fromList, isSubsetOf)
 import Data.Maybe (isNothing, fromJust)
 
-import LogicTasks.Helpers
+import LogicTasks.Helpers (extra)
 import Tasks.SubTree.Config (checkSubTreeConfig, SubTreeInst(..), SubTreeConfig(..))
 import Trees.Types (FormulaAnswer(..))
 import Trees.Print (display)

--- a/src/LogicTasks/Syntax/TreeToFormula.hs
+++ b/src/LogicTasks/Syntax/TreeToFormula.hs
@@ -19,7 +19,7 @@ import Data.Digest.Pure.SHA (sha1, showDigest)
 import Data.Maybe (fromJust, isNothing)
 import Image.LaTeX.Render (FormulaOptions(..), SVG, defaultEnv, imageForFormula)
 
-import LogicTasks.Helpers
+import LogicTasks.Helpers (extra)
 import Tasks.SynTree.Config (checkSynTreeConfig, SynTreeInst(..), SynTreeConfig)
 import Trees.Types (TreeFormulaAnswer(..))
 import Trees.Print (transferToPicture)

--- a/src/LogicTasks/Syntax/TreeToFormula.hs
+++ b/src/LogicTasks/Syntax/TreeToFormula.hs
@@ -16,7 +16,7 @@ import Control.Monad.Output (
   )
 import Data.ByteString.Lazy.UTF8 (fromString)
 import Data.Digest.Pure.SHA (sha1, showDigest)
-import Data.Maybe (fromJust, isNothing, fromMaybe)
+import Data.Maybe (fromJust, isNothing)
 import Image.LaTeX.Render (FormulaOptions(..), SVG, defaultEnv, imageForFormula)
 
 import LogicTasks.Helpers
@@ -45,7 +45,7 @@ description path SynTreeInst{..} = do
     keyHeading
     fullKey
 
-    paragraph $ text (fromMaybe "" extraText)
+    extra extraText
     pure ()
 
 

--- a/src/LogicTasks/Syntax/TreeToFormula.hs
+++ b/src/LogicTasks/Syntax/TreeToFormula.hs
@@ -19,7 +19,7 @@ import Data.Digest.Pure.SHA (sha1, showDigest)
 import Data.Maybe (fromJust, isNothing)
 import Image.LaTeX.Render (FormulaOptions(..), SVG, defaultEnv, imageForFormula)
 
-import LogicTasks.Helpers (extra)
+import LogicTasks.Helpers (cacheIO, extra, fullKey, instruct, keyHeading, reject)
 import Tasks.SynTree.Config (checkSynTreeConfig, SynTreeInst(..), SynTreeConfig)
 import Trees.Types (TreeFormulaAnswer(..))
 import Trees.Print (transferToPicture)

--- a/src/LogicTasks/Syntax/TreeToFormula.hs
+++ b/src/LogicTasks/Syntax/TreeToFormula.hs
@@ -45,7 +45,7 @@ description path SynTreeInst{..} = do
     keyHeading
     fullKey
 
-    extra extraText
+    extra addText
     pure ()
 
 

--- a/src/Tasks/LegalCNF/Config.hs
+++ b/src/Tasks/LegalCNF/Config.hs
@@ -118,5 +118,5 @@ data LegalCNFInst =
     {
         serialsOfWrong :: Set Int
       , formulaStrings :: [String]
-      , extraText :: Maybe (Map Language String)
+      , addText :: Maybe (Map Language String)
     } deriving (Show,Generic)

--- a/src/Tasks/LegalCNF/Config.hs
+++ b/src/Tasks/LegalCNF/Config.hs
@@ -12,9 +12,10 @@ module Tasks.LegalCNF.Config (
     ) where
 
 
-import Control.Monad.Output (LangM, OutputMonad, english, german)
+import Control.Monad.Output (LangM, OutputMonad, english, german, Language)
 import Data.Char (isLetter)
 import Data.Set (Set)
+import Data.Map (Map)
 import GHC.Generics (Generic)
 
 import Config (BaseConfig(..), CnfConfig(..), dCnfConf)
@@ -37,7 +38,7 @@ data LegalCNFConfig =
     , maxStringSize :: Int
     , minStringSize :: Int
     , allowArrowOperators :: Bool
-    , extraText :: Maybe String
+    , extraText :: Maybe (Map Language String)
   } deriving (Show,Generic)
 
 
@@ -117,5 +118,5 @@ data LegalCNFInst =
     {
         serialsOfWrong :: Set Int
       , formulaStrings :: [String]
-      , extraText :: Maybe String
+      , extraText :: Maybe (Map Language String)
     } deriving (Show,Generic)

--- a/src/Tasks/LegalCNF/Quiz.hs
+++ b/src/Tasks/LegalCNF/Quiz.hs
@@ -42,7 +42,7 @@ generateLegalCNFInst config@LegalCNFConfig {..} = do
         [1 .. formulas]
         config
       `suchThat` (listNoDuplicate . map (simplestDisplay . fmap (const '_')))
-    return $ LegalCNFInst {serialsOfWrong = fromList serialsOfWrong, formulaStrings = map simplestDisplay treeList, extraText = extraText}
+    return $ LegalCNFInst {serialsOfWrong = fromList serialsOfWrong, formulaStrings = map simplestDisplay treeList, addText = extraText}
 
 
 

--- a/src/Tasks/LegalCNF/Quiz.hs
+++ b/src/Tasks/LegalCNF/Quiz.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RecordWildCards, NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Tasks.LegalCNF.Quiz (
     generateLegalCNFInst

--- a/src/Tasks/LegalProposition/Config.hs
+++ b/src/Tasks/LegalProposition/Config.hs
@@ -10,9 +10,10 @@ module Tasks.LegalProposition.Config (
     ) where
 
 
-import Control.Monad.Output (LangM, OutputMonad, english, german)
+import Control.Monad.Output (LangM, OutputMonad, english, german, Language)
 import Data.Set (Set)
 import GHC.Generics (Generic)
+import Data.Map (Map)
 
 import LogicTasks.Helpers (reject)
 import Trees.Helpers (maxLeavesForNodes)
@@ -75,5 +76,5 @@ data LegalPropositionInst =
     {
       serialsOfWrong :: Set Int
     , pseudoFormulas :: [String]
-    , extraText :: Maybe String
+    , extraText :: Maybe (Map Language String)
     } deriving (Show,Generic)

--- a/src/Tasks/LegalProposition/Config.hs
+++ b/src/Tasks/LegalProposition/Config.hs
@@ -76,5 +76,5 @@ data LegalPropositionInst =
     {
       serialsOfWrong :: Set Int
     , pseudoFormulas :: [String]
-    , extraText :: Maybe (Map Language String)
+    , addText :: Maybe (Map Language String)
     } deriving (Show,Generic)

--- a/src/Tasks/LegalProposition/Quiz.hs
+++ b/src/Tasks/LegalProposition/Quiz.hs
@@ -43,7 +43,7 @@ generateLegalPropositionInst LegalPropositionConfig  {syntaxTreeConfig = SynTree
     return $ LegalPropositionInst
         { serialsOfWrong = fromList serialsOfWrong
         , pseudoFormulas = pseudoFormulas
-        , extraText = extraText
+        , addText = extraText
         }
 
 

--- a/src/Tasks/SubTree/Config.hs
+++ b/src/Tasks/SubTree/Config.hs
@@ -66,5 +66,5 @@ data SubTreeInst =
     { tree :: SynTree BinOp Char
     , correctFormulas :: Set String
     , minInputTrees :: Integer
-    , extraText :: Maybe (Map Language String)
+    , addText :: Maybe (Map Language String)
     } deriving (Show,Generic)

--- a/src/Tasks/SubTree/Config.hs
+++ b/src/Tasks/SubTree/Config.hs
@@ -10,9 +10,10 @@ module Tasks.SubTree.Config (
     ) where
 
 
-import Control.Monad.Output (LangM, OutputMonad, english, german)
+import Control.Monad.Output (LangM, OutputMonad, english, german, Language)
 import Data.Set (Set)
 import GHC.Generics (Generic)
+import Data.Map (Map)
 
 import LogicTasks.Helpers (reject)
 import Tasks.SynTree.Config(SynTreeConfig(..), checkSynTreeConfig, defaultSynTreeConfig)
@@ -65,5 +66,5 @@ data SubTreeInst =
     { tree :: SynTree BinOp Char
     , correctFormulas :: Set String
     , minInputTrees :: Integer
-    , extraText :: Maybe String
+    , extraText :: Maybe (Map Language String)
     } deriving (Show,Generic)

--- a/src/Tasks/SubTree/Quiz.hs
+++ b/src/Tasks/SubTree/Quiz.hs
@@ -33,5 +33,5 @@ generateSubTreeInst SubTreeConfig {syntaxTreeConfig = SynTreeConfig {..}, ..} = 
       { tree
       , minInputTrees = minSubTrees
       , correctFormulas = Data.Set.map display correctTrees
-      , extraText = extraText
+      , addText = extraText
       }

--- a/src/Tasks/SuperfluousBrackets/Config.hs
+++ b/src/Tasks/SuperfluousBrackets/Config.hs
@@ -10,8 +10,9 @@ module Tasks.SuperfluousBrackets.Config (
     )where
 
 
-import Control.Monad.Output (LangM, OutputMonad, english, german)
+import Control.Monad.Output (LangM, OutputMonad, english, german, Language)
 import GHC.Generics (Generic)
+import Data.Map (Map)
 
 import LogicTasks.Helpers (reject)
 import Tasks.SynTree.Config(SynTreeConfig(..), checkSynTreeConfig, defaultSynTreeConfig)
@@ -66,5 +67,5 @@ data SuperfluousBracketsInst =
       tree :: SynTree BinOp Char
     , stringWithSuperfluousBrackets :: String
     , simplestString :: String
-    , extraText :: Maybe String
+    , extraText :: Maybe (Map Language String)
     } deriving (Show,Generic)

--- a/src/Tasks/SuperfluousBrackets/Config.hs
+++ b/src/Tasks/SuperfluousBrackets/Config.hs
@@ -67,5 +67,5 @@ data SuperfluousBracketsInst =
       tree :: SynTree BinOp Char
     , stringWithSuperfluousBrackets :: String
     , simplestString :: String
-    , extraText :: Maybe (Map Language String)
+    , addText :: Maybe (Map Language String)
     } deriving (Show,Generic)

--- a/src/Tasks/SuperfluousBrackets/Quiz.hs
+++ b/src/Tasks/SuperfluousBrackets/Quiz.hs
@@ -32,5 +32,5 @@ generateSuperfluousBracketsInst SuperfluousBracketsConfig {syntaxTreeConfig = Sy
       { tree
       , stringWithSuperfluousBrackets
       , simplestString = simplestDisplay tree
-      , extraText = extraText
+      , addText = extraText
       }

--- a/src/Tasks/SynTree/Config.hs
+++ b/src/Tasks/SynTree/Config.hs
@@ -101,5 +101,5 @@ data SynTreeInst =
     { tree :: SynTree BinOp Char
     , latexImage :: String
     , correct :: String
-    , extraText :: Maybe (Map Language String)
+    , addText :: Maybe (Map Language String)
     } deriving (Show,Generic)

--- a/src/Tasks/SynTree/Config.hs
+++ b/src/Tasks/SynTree/Config.hs
@@ -11,9 +11,10 @@ module Tasks.SynTree.Config (
     ) where
 
 
-import Control.Monad.Output (LangM, OutputMonad, english, german)
+import Control.Monad.Output (LangM, OutputMonad, english, german, Language)
 import Data.Char (isLetter)
 import GHC.Generics (Generic)
+import Data.Map (Map)
 
 import LogicTasks.Helpers (reject)
 import Trees.Helpers (maxNodesForDepth)
@@ -31,7 +32,7 @@ data SynTreeConfig =
   , atLeastOccurring :: Integer
   , allowArrowOperators :: Bool
   , maxConsecutiveNegations :: Integer
-  , extraText :: Maybe String
+  , extraText :: Maybe (Map Language String)
   } deriving (Show,Generic)
 
 
@@ -100,5 +101,5 @@ data SynTreeInst =
     { tree :: SynTree BinOp Char
     , latexImage :: String
     , correct :: String
-    , extraText :: Maybe String
+    , extraText :: Maybe (Map Language String)
     } deriving (Show,Generic)

--- a/src/Tasks/SynTree/Quiz.hs
+++ b/src/Tasks/SynTree/Quiz.hs
@@ -27,5 +27,5 @@ generateSynTreeInst SynTreeConfig {..} = do
       { tree
       , latexImage = transferToPicture tree
       , correct = display tree
-      , extraText = extraText
+      , addText = extraText
       }


### PR DESCRIPTION
Mit diesem Pull Request wird es ermöglicht `extraText` in verschiedenen Sprachen zu definieren (siehe #62). Der Typ wurde entsprechend von `Maybe String` nach `Maybe (Map Language String)` geändert. Die Erstellung einer Config mit `extraText` könnte z.B. so aussehen:

```haskell
dPickInst :: PickInst
dPickInst =  PickInst
          { cnfs = [mkCnf [mkClause [Literal 'A', Not 'B']], mkCnf [mkClause [Not 'A', Literal 'B']]]
          , correct = 1
          , extraText = Just (fromList [(German, "Hallo Welt"),(English, "Hello World")])
          }
```

oder so:

```haskell
dPickInst :: PickInst
dPickInst =  PickInst
          { cnfs = [mkCnf [mkClause [Literal 'A', Not 'B']], mkCnf [mkClause [Not 'A', Literal 'B']]]
          , correct = 1
          , extraText = Just (translations $ do
              german "Hallo Welt"
              english "Hello World"
            )
          }
```

Bei https://github.com/nimec01/logic-tasks/blob/41812bc5189b511f5c20def13eb6328bb1cd8a2d/src/Formula/Printing.hs#L147 als auch bei https://github.com/nimec01/logic-tasks/blob/41812bc5189b511f5c20def13eb6328bb1cd8a2d/src/Formula/Parsing.hs#L303 musste ich aufgrund des neuen Typs Änderungen vornehmen, bin mir da aber unsicher, ob das so funktioniert wie es soll. Das sollte nochmal jemand überprüfen, der mehr in der Materie ist.
