### PR TITLE
Timeouts bei Tests hinterlegen.

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -17,6 +17,8 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    timeout-minutes: 30
+
     steps:
       - uses: actions/checkout@v2
 

--- a/test/LegalCNFSpec.hs
+++ b/test/LegalCNFSpec.hs
@@ -5,7 +5,7 @@ module LegalCNFSpec (spec) where
 import Data.Set (toList)
 import Data.Either(isLeft, isRight)
 import Test.Hspec (Spec, describe, it, xit)
-import Test.QuickCheck (Gen, choose, forAll, suchThat, sublistOf, elements, ioProperty, withMaxSuccess)
+import Test.QuickCheck (Gen, choose, forAll, suchThat, sublistOf, elements, ioProperty, withMaxSuccess, within)
 import Data.List((\\))
 
 import ParsingHelpers (fully)
@@ -97,6 +97,9 @@ invalidBoundsLegalCNF = do
           extraText = Nothing
         }
 
+timeout :: Int
+timeout = 30000000 -- 30 seconds
+
 spec :: Spec
 spec = do
     describe "validBoundsLegalCNF" $
@@ -127,11 +130,11 @@ spec = do
                   (judgeCnfSynTree . cnfToSynTree)
     describe "generateLegalCNFInst" $ do
         it "all of the formulas in the wrong serial should not be Cnf" $
-            forAll validBoundsLegalCNF $ \config ->
+            within timeout $ forAll validBoundsLegalCNF $ \config ->
                 forAll (generateLegalCNFInst config) $ \LegalCNFInst{..} ->
                   all (\x -> isLeft (cnfParse (formulaStrings !! (x - 1)))) (toList serialsOfWrong)
         it "all of the formulas not in the wrong serial should be Cnf" $
-            forAll validBoundsLegalCNF $ \config@LegalCNFConfig{..} ->
+            within timeout $ forAll validBoundsLegalCNF $ \config@LegalCNFConfig{..} ->
                 forAll (generateLegalCNFInst config) $ \LegalCNFInst{..} ->
                   all (\x -> isRight (cnfParse (formulaStrings !! (x - 1)))) ([1..formulas] \\ toList serialsOfWrong)
 


### PR DESCRIPTION
Dies beschränkt erstmal den Workflow auf maximal 30 Minuten. Wenn https://github.com/fmidue/logic-tasks/issues/75#issuecomment-1874303215 geklärt ist, können auch noch die einzelnen Tests mit Timeouts versehen werden.