### PR TITLE
Feedback anpassen

### DIFF
--- a/src/LogicTasks/Semantics/Fill.hs
+++ b/src/LogicTasks/Semantics/Fill.hs
@@ -158,16 +158,16 @@ partialGrade FillInst{..} sol = do
 
 completeGrade :: OutputMonad m => FillInst -> [TruthValue] -> LangM m
 completeGrade FillInst{..} sol = do
-  preventWithHint (not ((null diffShort && solLen == length missing) || (null diffLong && solLen == length allEntries)))
+  preventWithHint (not ((null diffShort && isShort) || (null diffLong && isLong)))
     (translate $ do
       german "Lösung ist korrekt?"
       english "Solution is correct?"
     )
     (do
-      translate $ do
+      when (solLen == length missing ||solLen == length allEntries) $ translate $ do
         german $ "Die Lösung beinhaltet " ++ displayMistake ++ " Fehler."
         english $ "Your solution contains " ++ displayMistake ++ " mistakes."
-      when showSolution $ example (show missing) $ do
+      when showSolution $ example (show correctShort) $ do
         english "The solution for this task is:"
         german "Die Lösung für die Aufgabe ist:"
       pure ()
@@ -184,4 +184,6 @@ completeGrade FillInst{..} sol = do
     zippedLong = zip3 boolSol allEntries [1..]
     (_,diffShort) = pairwiseCheck zippedShort
     (_,diffLong) = pairwiseCheck zippedLong
-    displayMistake = show (max (length diffShort) (length diffLong))
+    isShort = solLen == length missing
+    isLong = solLen == length allEntries
+    displayMistake = show $ length (if isShort then diffShort else diffLong)

--- a/src/LogicTasks/Syntax/SubTreeSet.hs
+++ b/src/LogicTasks/Syntax/SubTreeSet.hs
@@ -106,7 +106,7 @@ completeGrade path SubTreeInst{..} sol = refuseIfWrong $ do
         english "Your solution is incorrect."
         german "Ihre Lösung ist falsch."
 
-  when (showSolution && not partOfSolution) $ indent $ do
+  when showSolution $ indent $ do
     instruct $ do
       english ("A possible solution for this task contains " ++ show minInputTrees ++ " of the following subformulas:")
       german ("Eine mögliche Lösung für die Aufgabe beinhaltet " ++ show minInputTrees ++ " der folgenden Teilformeln:")

--- a/src/LogicTasks/Syntax/SubTreeSet.hs
+++ b/src/LogicTasks/Syntax/SubTreeSet.hs
@@ -106,7 +106,7 @@ completeGrade path SubTreeInst{..} sol = refuseIfWrong $ do
         english "Your solution is incorrect."
         german "Ihre Lösung ist falsch."
 
-  when showSolution $ indent $ do
+  when (showSolution && not partOfSolution) $ indent $ do
     instruct $ do
       english ("A possible solution for this task contains " ++ show minInputTrees ++ " of the following subformulas:")
       german ("Eine mögliche Lösung für die Aufgabe beinhaltet " ++ show minInputTrees ++ " der folgenden Teilformeln:")

--- a/src/Tasks/LegalCNF/Quiz.hs
+++ b/src/Tasks/LegalCNF/Quiz.hs
@@ -44,7 +44,7 @@ generateLegalCNFInst config@LegalCNFConfig {..} = do
       `suchThat` (listNoDuplicate . map (simplestDisplay . fmap (const '_')))
     return $ LegalCNFInst { serialsOfWrong = fromList serialsOfWrong
                           , formulaStrings = map simplestDisplay treeList
-                          , showSolution = False
+                          , showSolution = printSolution
                           , addText = extraText}
 
 


### PR DESCRIPTION
Wie in #92 schon angeschnitten, gab es noch bei ein paar Aufgabentypen Verbesserungsmöglichkeiten.

**SubTreeSet**:
- Hier wurde trotz korrekter Einsendung noch die "richtige Lösung" angezeigt. Das ist jetzt nicht mehr der Fall.

**Fill**: 
- Die "richtige Lösung" hatte hier nur die Zeilennummern der fehlenden Werte angezeigt. Jetzt werden die richtigen, fehlenden Werte angezeigt.
- Es konnte vorkommen, dass bei Angabe der "kurzen Variante" die falsche Anzahl an Fehlern in der Lösung angezeigt wird. Es wird nun ermittelt, ob die kurze oder lange Variante eingegeben wurde und die entsprechende Anzahl der Fehler ausgegeben.

**IllegalCNF**:
- Hier war der Generator fehlerhaft. Der Wert von `showSolution` wurde immer auf `False` gesetzt. Jetzt nimmt er den entsprechenden Wert von `printSolution` aus der Config an.