### PR TITLE
Flag `useSetNotation` bei Aufgabentyp Step und Resolve

### DIFF
--- a/examples/src/Semantics/Resolution/Complete/Config.hs
+++ b/examples/src/Semantics/Resolution/Complete/Config.hs
@@ -19,6 +19,7 @@ task15 = ResolutionConfig
       }
     , minSteps = 3
     , printFeedbackImmediately = True
+    , displayUsingSetNotation = False
     , printSolution = True
     , extraText = Nothing
     }
@@ -33,6 +34,7 @@ task16 =  ResolutionConfig
       }
   , minSteps = 4
   , printFeedbackImmediately = True
+  , displayUsingSetNotation = False
   , printSolution = True
   , extraText = Nothing
   }

--- a/examples/src/Semantics/Resolution/Complete/Config.hs
+++ b/examples/src/Semantics/Resolution/Complete/Config.hs
@@ -19,7 +19,7 @@ task15 = ResolutionConfig
       }
     , minSteps = 3
     , printFeedbackImmediately = True
-    , displayUsingSetNotation = False
+    , useSetNotation = False
     , printSolution = True
     , extraText = Nothing
     }
@@ -34,7 +34,7 @@ task16 =  ResolutionConfig
       }
   , minSteps = 4
   , printFeedbackImmediately = True
-  , displayUsingSetNotation = False
+  , useSetNotation = False
   , printSolution = True
   , extraText = Nothing
   }

--- a/examples/src/Semantics/Resolution/Step/Config.hs
+++ b/examples/src/Semantics/Resolution/Step/Config.hs
@@ -18,7 +18,7 @@ task12 =
       , maxClauseLength = 2
       , usedLiterals = "ABCD"
       }
-    , displayUsingSetNotation = False
+    , useSetNotation = False
     , extraText = Nothing
     , printSolution = True
     }
@@ -36,7 +36,7 @@ task14 =
       , maxClauseLength = 3
       , usedLiterals = "ABCD"
       }
-    , displayUsingSetNotation = False
+    , useSetNotation = False
     , extraText = Nothing
     , printSolution = True
     }

--- a/examples/src/Semantics/Resolution/Step/Config.hs
+++ b/examples/src/Semantics/Resolution/Step/Config.hs
@@ -18,6 +18,7 @@ task12 =
       , maxClauseLength = 2
       , usedLiterals = "ABCD"
       }
+    , displayUsingSetNotation = False
     , extraText = Nothing
     , printSolution = True
     }
@@ -35,6 +36,7 @@ task14 =
       , maxClauseLength = 3
       , usedLiterals = "ABCD"
       }
+    , displayUsingSetNotation = False
     , extraText = Nothing
     , printSolution = True
     }

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -151,6 +151,7 @@ dDecideInst =  DecideInst
 data StepInst = StepInst {
                  clause1 :: !Clause
                , clause2 :: !Clause
+               , showAsSet :: Bool
                , showSolution :: Bool
                , addText :: Maybe (Map Language String)
                }
@@ -160,6 +161,7 @@ dStepInst :: StepInst
 dStepInst =  StepInst
           { clause1 = mkClause [Not 'A', Not 'C', Literal 'B']
           , clause2 = mkClause [Literal 'A', Not 'C']
+          , showAsSet = False
           , showSolution = False
           , addText = Nothing
           }
@@ -170,6 +172,7 @@ data ResolutionInst = ResolutionInst {
                  clauses :: ![Clause]
                , solution :: [ResStep]
                , printFeedbackImmediately :: Bool
+               , showAsSet :: Bool
                , showSolution :: Bool
                , addText    :: Maybe (Map Language String)
                }
@@ -198,6 +201,7 @@ dResInst = let
                     , Res (Left nC    , Left pC, (mkClause [], Nothing))
                     ]
                 , printFeedbackImmediately = True
+                , showAsSet = False
                 , showSolution = False
                 , addText = Nothing
                 }
@@ -337,6 +341,7 @@ dDecideConf = DecideConfig
 
 data StepConfig = StepConfig {
       baseConf :: BaseConfig
+    , displayUsingSetNotation :: Bool
     , printSolution :: Bool
     , extraText :: Maybe (Map Language String)
     }
@@ -345,6 +350,7 @@ data StepConfig = StepConfig {
 dStepConf :: StepConfig
 dStepConf = StepConfig
     { baseConf = dBaseConf
+    , displayUsingSetNotation = False
     , printSolution = False
     , extraText = Nothing
     }
@@ -378,6 +384,7 @@ data ResolutionConfig = ResolutionConfig {
       baseConf :: BaseConfig
     , minSteps :: Int
     , printFeedbackImmediately :: Bool
+    , displayUsingSetNotation :: Bool
     , printSolution :: Bool
     , extraText :: Maybe (Map Language String)
     }
@@ -388,6 +395,7 @@ dResConf = ResolutionConfig
     { baseConf = dBaseConf
     , minSteps = 2
     , printFeedbackImmediately = True
+    , displayUsingSetNotation = False
     , printSolution = False
     , extraText = Nothing
     }

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -201,7 +201,7 @@ dResInst = let
                     , Res (Left nC    , Left pC, (mkClause [], Nothing))
                     ]
                 , printFeedbackImmediately = True
-                , usesSetNotation = False
+                , usesSetNotation = True
                 , showSolution = False
                 , addText = Nothing
                 }
@@ -395,7 +395,7 @@ dResConf = ResolutionConfig
     { baseConf = dBaseConf
     , minSteps = 2
     , printFeedbackImmediately = True
-    , useSetNotation = False
+    , useSetNotation = True
     , printSolution = False
     , extraText = Nothing
     }

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -151,7 +151,7 @@ dDecideInst =  DecideInst
 data StepInst = StepInst {
                  clause1 :: !Clause
                , clause2 :: !Clause
-               , showAsSet :: Bool
+               , usesSetNotation :: Bool
                , showSolution :: Bool
                , addText :: Maybe (Map Language String)
                }
@@ -161,7 +161,7 @@ dStepInst :: StepInst
 dStepInst =  StepInst
           { clause1 = mkClause [Not 'A', Not 'C', Literal 'B']
           , clause2 = mkClause [Literal 'A', Not 'C']
-          , showAsSet = False
+          , usesSetNotation = False
           , showSolution = False
           , addText = Nothing
           }
@@ -172,7 +172,7 @@ data ResolutionInst = ResolutionInst {
                  clauses :: ![Clause]
                , solution :: [ResStep]
                , printFeedbackImmediately :: Bool
-               , showAsSet :: Bool
+               , usesSetNotation :: Bool
                , showSolution :: Bool
                , addText    :: Maybe (Map Language String)
                }
@@ -201,7 +201,7 @@ dResInst = let
                     , Res (Left nC    , Left pC, (mkClause [], Nothing))
                     ]
                 , printFeedbackImmediately = True
-                , showAsSet = False
+                , usesSetNotation = False
                 , showSolution = False
                 , addText = Nothing
                 }
@@ -341,7 +341,7 @@ dDecideConf = DecideConfig
 
 data StepConfig = StepConfig {
       baseConf :: BaseConfig
-    , displayUsingSetNotation :: Bool
+    , useSetNotation :: Bool
     , printSolution :: Bool
     , extraText :: Maybe (Map Language String)
     }
@@ -350,7 +350,7 @@ data StepConfig = StepConfig {
 dStepConf :: StepConfig
 dStepConf = StepConfig
     { baseConf = dBaseConf
-    , displayUsingSetNotation = False
+    , useSetNotation = False
     , printSolution = False
     , extraText = Nothing
     }
@@ -384,7 +384,7 @@ data ResolutionConfig = ResolutionConfig {
       baseConf :: BaseConfig
     , minSteps :: Int
     , printFeedbackImmediately :: Bool
-    , displayUsingSetNotation :: Bool
+    , useSetNotation :: Bool
     , printSolution :: Bool
     , extraText :: Maybe (Map Language String)
     }
@@ -395,7 +395,7 @@ dResConf = ResolutionConfig
     { baseConf = dBaseConf
     , minSteps = 2
     , printFeedbackImmediately = True
-    , displayUsingSetNotation = False
+    , useSetNotation = False
     , printSolution = False
     , extraText = Nothing
     }

--- a/src/Formula/Helpers.hs
+++ b/src/Formula/Helpers.hs
@@ -1,6 +1,14 @@
 {-# LANGUAGE RecordWildCards #-}
 module Formula.Helpers where
-import Formula.Types (PrologLiteral (..), PrologClause(..), terms, ClauseShape(AnyClause, HornClause), HornShape (..), Clause(..), Cnf(..))
+import Formula.Types (
+  PrologLiteral (..),
+  PrologClause(..),
+  ClauseShape(AnyClause, HornClause),
+  HornShape (..),
+  Clause(..),
+  Cnf(..),
+  terms
+  )
 import Data.Foldable (Foldable(toList))
 import Data.List (intercalate)
 

--- a/src/Formula/Helpers.hs
+++ b/src/Formula/Helpers.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE RecordWildCards #-}
 module Formula.Helpers where
-import Formula.Types (PrologLiteral (..), PrologClause(..), terms, ClauseShape(AnyClause, HornClause), HornShape (..))
+import Formula.Types (PrologLiteral (..), PrologClause(..), terms, ClauseShape(AnyClause, HornClause), HornShape (..), Clause(..), Cnf(..))
+import Data.Foldable (Foldable(toList))
+import Data.List (intercalate)
 
 hasTheClauseShape :: ClauseShape -> PrologClause -> Bool
 hasTheClauseShape AnyClause _ = True
@@ -12,3 +14,13 @@ hasTheClauseShape (HornClause hornShape) clause =
         Fact -> positiveLiteralCount == 1 && negativeLiteralCount == 0
         Procedure -> positiveLiteralCount == 1 && negativeLiteralCount > 0
         Query -> positiveLiteralCount == 0 && negativeLiteralCount > 0
+
+showClauseAsSet :: Clause -> String
+showClauseAsSet Clause{..}
+  | null literalSet = "{ }"
+  | otherwise = "{ " ++ intercalate ", " (map show (toList literalSet)) ++ " }"
+
+showCnfAsSet :: Cnf -> String
+showCnfAsSet Cnf{..}
+  | null clauseSet = "{ }"
+  | otherwise = "{ " ++ intercalate ", " (map showClauseAsSet (toList clauseSet)) ++ " }"

--- a/src/Formula/Parsing/Delayed.hs
+++ b/src/Formula/Parsing/Delayed.hs
@@ -1,5 +1,12 @@
 {-# LANGUAGE FlexibleContexts #-}
-module Formula.Parsing.Delayed (Delayed, delayed, withDelayed, parseDelayedAndThen, complainAboutMissingParenthesesIfNotFailingOn) where
+module Formula.Parsing.Delayed (
+  Delayed,
+  delayed,
+  withDelayed,
+  parseDelayedAndThen,
+  complainAboutMissingParenthesesIfNotFailingOn,
+  complainAboutWrongNotation
+  ) where
 
 import Text.Parsec (ParseError, parse)
 import Text.Parsec.String (Parser)
@@ -60,3 +67,15 @@ complainAboutMissingParenthesesIfNotFailingOn maybeHereError latentError =
           , "Please make sure that the arrangement of symbols adheres to the rules for well-formed inputs."
           , "In particular, you should use enough parentheses."
           ]
+
+complainAboutWrongNotation :: Maybe a -> ParseError -> State (Map Language String) ()
+complainAboutWrongNotation _ _ = do
+  german $  unlines
+    [ "Ihre Abgabe konnte nicht gelesen werden." {- german -}
+    , "Bitte stellen Sie sicher, dass Sie die geforderte Notation verwenden." {- german -}
+    ]
+  english $ unlines
+    [ "Unable to read solution."
+    , "Please make sure to use the required notation."
+    ]
+

--- a/src/LogicTasks/Semantics/Resolve.hs
+++ b/src/LogicTasks/Semantics/Resolve.hs
@@ -114,14 +114,24 @@ description ResolutionInst{..} = do
     german "Neu resolvierte Klauseln können mit einer Nummer versehen werden, indem Sie '= NUMMER' an diese anfügen."
     english "Newly resolved clauses can be associated with a number by attaching '= NUMBER' behind them."
 
-  paragraph $ indent $ do
+  when usesSetNotation $ paragraph $ indent $ do
     translate $ do
-      german "Ein Lösungsversuch könnte beispielsweise so aussehen: "
-      english "A solution attempt could look like this: "
+      german "Nutzen Sie zur Angabe der Klauseln die Mengennotation!. Ein Lösungsversuch könnte beispielsweise so aussehen: "
+      english "Specify the clauses using set notation! A solution attempt could look like this: "
     translatedCode $ flip localise $ translations $ do
       english "[(1, 2, {A}), (3, 4, {-A, -B} = 6), (5, 6, {not A}), ({A}, {not A}, {})]"
       german "[(1, 2, {A}), (3, 4, {-A, -B} = 6), (5, 6, {nicht A}), ({A}, {nicht A}, {})]"
     pure ()
+
+  unless usesSetNotation $ paragraph $ indent $ do
+    translate $ do
+      german "Nutzen Sie zur Angabe der Klauseln eine Formel! Ein Lösungsversuch könnte beispielsweise so aussehen: "
+      english "Specify the clauses using a formula! A solution attempt could look like this: "
+    translatedCode $ flip localise $ translations $ do
+      english "[(1, 2, A), (3, 4, -A or -B = 6), (5, 6, not A), (A, not A, {})]"
+      german "[(1, 2, A), (3, 4, -A oder -B = 6), (5, 6, nicht A), (A, nicht A, {})]"
+    pure ()
+
   extra addText
   pure ()
     where

--- a/src/LogicTasks/Semantics/Resolve.hs
+++ b/src/LogicTasks/Semantics/Resolve.hs
@@ -36,6 +36,8 @@ import Data.Foldable.Extra (notNull)
 import Text.PrettyPrint.Leijen.Text (Pretty(pretty))
 import Formula.Parsing.Delayed (Delayed, withDelayed)
 import Formula.Parsing (Parse(..))
+import Formula.Helpers (showCnfAsSet)
+
 
 
 
@@ -59,6 +61,7 @@ genResInst ResolutionConfig{ baseConf = BaseConfig{..}, ..} = do
     clauses = clauses,
     solution,
     printFeedbackImmediately = printFeedbackImmediately,
+    showAsSet = displayUsingSetNotation,
     showSolution = printSolution,
     addText = extraText
   }
@@ -73,7 +76,7 @@ description ResolutionInst{..} = do
     translate $ do
       german "Betrachten Sie die folgende Formel in KNF:"
       english "Consider the following formula in cnf:"
-    indent $ code $ show $ mkCnf clauses
+    indent $ code $ show' clauses
     pure ()
   paragraph $ translate $ do
     german "Führen Sie das Resolutionsverfahren an dieser Formel durch, um die leere Klausel abzuleiten."
@@ -121,6 +124,10 @@ description ResolutionInst{..} = do
     pure ()
   extra addText
   pure ()
+    where
+      show' = if showAsSet
+        then showCnfAsSet . mkCnf
+        else show . mkCnf
 
 
 verifyStatic :: OutputCapable m => ResolutionInst -> LangM m

--- a/src/LogicTasks/Semantics/Resolve.hs
+++ b/src/LogicTasks/Semantics/Resolve.hs
@@ -35,7 +35,7 @@ import Control.Applicative (Alternative)
 import Data.Foldable.Extra (notNull)
 import Text.PrettyPrint.Leijen.Text (Pretty(pretty))
 import Formula.Parsing.Delayed (Delayed, withDelayed)
-import Formula.Parsing (Parse(..))
+import Formula.Parsing (resStepsParser, clauseSetParser, clauseFormulaParser)
 import Formula.Helpers (showCnfAsSet)
 
 
@@ -208,7 +208,9 @@ gradeSteps steps appliedIsNothing = do
       checkEmptyClause = null steps || not (isEmptyClause $ third3 $ last steps)
 
 partialGrade :: OutputCapable m => ResolutionInst -> Delayed [ResStep] -> LangM m
-partialGrade inst = partialGrade' inst `withDelayed` parser
+partialGrade inst = partialGrade' inst `withDelayed` resStepsParser clauseParser
+  where clauseParser | showAsSet inst = clauseSetParser
+                     | otherwise      = clauseFormulaParser
 
 partialGrade' :: OutputCapable m => ResolutionInst -> [ResStep] -> LangM m
 partialGrade' ResolutionInst{..} sol = do
@@ -241,7 +243,9 @@ partialGrade' ResolutionInst{..} sol = do
     stepsGraded = gradeSteps steps (isNothing applied)
 
 completeGrade :: (OutputCapable m, Alternative m) => ResolutionInst -> Delayed [ResStep] -> LangM m
-completeGrade inst = completeGrade' inst `withDelayed` parser
+completeGrade inst = completeGrade' inst `withDelayed` resStepsParser clauseParser
+  where clauseParser | showAsSet inst = clauseSetParser
+                     | otherwise      = clauseFormulaParser
 
 completeGrade' :: (OutputCapable m, Alternative m) => ResolutionInst -> [ResStep] -> LangM m
 completeGrade' ResolutionInst{..} sol = (if isCorrect then id else refuse) $ do

--- a/src/LogicTasks/Semantics/Resolve.hs
+++ b/src/LogicTasks/Semantics/Resolve.hs
@@ -28,7 +28,7 @@ import Config (ResolutionConfig(..), ResolutionInst(..), BaseConfig(..))
 import Formula.Util (isEmptyClause, mkCnf, sat)
 import Formula.Resolution (applySteps, genRes, resolvableWith, resolve)
 import Formula.Types (Clause, ResStep(..), literals)
-import LogicTasks.Helpers (example, extra, keyHeading, negationKey)
+import LogicTasks.Helpers (example, extra, keyHeading, negationKey, orKey)
 import Util (checkBaseConf, prevent, preventWithHint)
 import Control.Monad (unless, when)
 import Control.Applicative (Alternative)
@@ -88,8 +88,9 @@ description ResolutionInst{..} = do
 
   keyHeading
   negationKey
+  unless usesSetNotation orKey
 
-  paragraph $ indent $ do
+  when usesSetNotation $ paragraph $ indent $ do
     translate $ do
       german "Nicht-leere Klausel:"
       english "Non-empty clause:"

--- a/src/LogicTasks/Semantics/Resolve.hs
+++ b/src/LogicTasks/Semantics/Resolve.hs
@@ -30,11 +30,11 @@ import Formula.Resolution (applySteps, genRes, resolvableWith, resolve)
 import Formula.Types (Clause, ResStep(..), literals)
 import LogicTasks.Helpers (example, extra, keyHeading, negationKey)
 import Util (checkBaseConf, prevent, preventWithHint)
-import Control.Monad (unless, when, void)
+import Control.Monad (unless, when)
 import Control.Applicative (Alternative)
 import Data.Foldable.Extra (notNull)
 import Text.PrettyPrint.Leijen.Text (Pretty(pretty))
-import Formula.Parsing.Delayed (Delayed, withDelayed, parseDelayedAndThen, complainAboutWrongNotation)
+import Formula.Parsing.Delayed (Delayed, withDelayed, parseDelayedWithAndThen, complainAboutWrongNotation)
 import Formula.Parsing (resStepsParser, clauseSetParser, clauseFormulaParser)
 import Formula.Helpers (showCnfAsSet)
 
@@ -218,7 +218,7 @@ gradeSteps steps appliedIsNothing = do
       checkEmptyClause = null steps || not (isEmptyClause $ third3 $ last steps)
 
 partialGrade :: OutputCapable m => ResolutionInst -> Delayed [ResStep] -> LangM m
-partialGrade inst = parseDelayedAndThen complainAboutWrongNotation (void clauseParser) $ partialGrade' inst
+partialGrade inst = parseDelayedWithAndThen (resStepsParser clauseParser) complainAboutWrongNotation (pure ()) $ partialGrade' inst
   where clauseParser | usesSetNotation inst = clauseSetParser
                      | otherwise      = clauseFormulaParser
 

--- a/src/LogicTasks/Semantics/Resolve.hs
+++ b/src/LogicTasks/Semantics/Resolve.hs
@@ -30,11 +30,11 @@ import Formula.Resolution (applySteps, genRes, resolvableWith, resolve)
 import Formula.Types (Clause, ResStep(..), literals)
 import LogicTasks.Helpers (example, extra, keyHeading, negationKey)
 import Util (checkBaseConf, prevent, preventWithHint)
-import Control.Monad (unless, when)
+import Control.Monad (unless, when, void)
 import Control.Applicative (Alternative)
 import Data.Foldable.Extra (notNull)
 import Text.PrettyPrint.Leijen.Text (Pretty(pretty))
-import Formula.Parsing.Delayed (Delayed, withDelayed)
+import Formula.Parsing.Delayed (Delayed, withDelayed, parseDelayedAndThen, complainAboutWrongNotation)
 import Formula.Parsing (resStepsParser, clauseSetParser, clauseFormulaParser)
 import Formula.Helpers (showCnfAsSet)
 
@@ -218,7 +218,7 @@ gradeSteps steps appliedIsNothing = do
       checkEmptyClause = null steps || not (isEmptyClause $ third3 $ last steps)
 
 partialGrade :: OutputCapable m => ResolutionInst -> Delayed [ResStep] -> LangM m
-partialGrade inst = partialGrade' inst `withDelayed` resStepsParser clauseParser
+partialGrade inst = parseDelayedAndThen complainAboutWrongNotation (void clauseParser) $ partialGrade' inst
   where clauseParser | usesSetNotation inst = clauseSetParser
                      | otherwise      = clauseFormulaParser
 

--- a/src/LogicTasks/Semantics/Resolve.hs
+++ b/src/LogicTasks/Semantics/Resolve.hs
@@ -61,7 +61,7 @@ genResInst ResolutionConfig{ baseConf = BaseConfig{..}, ..} = do
     clauses = clauses,
     solution,
     printFeedbackImmediately = printFeedbackImmediately,
-    showAsSet = displayUsingSetNotation,
+    usesSetNotation = useSetNotation,
     showSolution = printSolution,
     addText = extraText
   }
@@ -125,7 +125,7 @@ description ResolutionInst{..} = do
   extra addText
   pure ()
     where
-      show' = if showAsSet
+      show' = if usesSetNotation
         then showCnfAsSet . mkCnf
         else show . mkCnf
 
@@ -209,7 +209,7 @@ gradeSteps steps appliedIsNothing = do
 
 partialGrade :: OutputCapable m => ResolutionInst -> Delayed [ResStep] -> LangM m
 partialGrade inst = partialGrade' inst `withDelayed` resStepsParser clauseParser
-  where clauseParser | showAsSet inst = clauseSetParser
+  where clauseParser | usesSetNotation inst = clauseSetParser
                      | otherwise      = clauseFormulaParser
 
 partialGrade' :: OutputCapable m => ResolutionInst -> [ResStep] -> LangM m
@@ -244,7 +244,7 @@ partialGrade' ResolutionInst{..} sol = do
 
 completeGrade :: (OutputCapable m, Alternative m) => ResolutionInst -> Delayed [ResStep] -> LangM m
 completeGrade inst = completeGrade' inst `withDelayed` resStepsParser clauseParser
-  where clauseParser | showAsSet inst = clauseSetParser
+  where clauseParser | usesSetNotation inst = clauseSetParser
                      | otherwise      = clauseFormulaParser
 
 completeGrade' :: (OutputCapable m, Alternative m) => ResolutionInst -> [ResStep] -> LangM m

--- a/src/LogicTasks/Semantics/Step.hs
+++ b/src/LogicTasks/Semantics/Step.hs
@@ -22,7 +22,7 @@ import Config (StepAnswer(..), StepConfig(..), StepInst(..), BaseConfig(..))
 import Formula.Util (isEmptyClause, mkClause)
 import Formula.Types (Clause(Clause, literalSet), Literal(..), genClause, literals, opposite)
 import Formula.Resolution (resolvable, resolve)
-import LogicTasks.Helpers (clauseKey, example, extra)
+import LogicTasks.Helpers (example, extra, keyHeading, negationKey, orKey)
 import Util (checkBaseConf, prevent, preventWithHint, tryGen)
 import Control.Monad (when, unless)
 import Formula.Parsing.Delayed (Delayed, withDelayed, parseDelayedWithAndThen, complainAboutWrongNotation)
@@ -65,7 +65,16 @@ description StepInst{..} = do
     german "Geben Sie das in dem Resolutionsschritt genutzte Literal (in positiver oder negativer Form) und das Ergebnis in der folgenden Tupelform an: (Literal, Resolvente)."
     english "Provide the literal (in positive or negative form) used for the step and the resolvent in the following tuple form: (literal, resolvent)."
 
-  clauseKey
+  keyHeading
+  negationKey
+  unless usesSetNotation orKey
+
+  when usesSetNotation $ paragraph $ indent $ do
+    translate $ do
+      german "Nicht-leere Klausel:"
+      english "Non-empty clause:"
+    code "{ ... }"
+    pure ()
 
   when usesSetNotation $ paragraph $ indent $ do
     translate $ do

--- a/src/LogicTasks/Semantics/Step.hs
+++ b/src/LogicTasks/Semantics/Step.hs
@@ -27,6 +27,9 @@ import Util (checkBaseConf, prevent, preventWithHint, tryGen)
 import Control.Monad (when)
 import Formula.Parsing.Delayed (Delayed, withDelayed)
 import Formula.Parsing (Parse(..))
+import Formula.Helpers (showClauseAsSet)
+
+
 
 
 genStepInst :: StepConfig -> Gen StepInst
@@ -35,7 +38,13 @@ genStepInst StepConfig{ baseConf = BaseConfig{..}, ..} = do
     let
       litAddedClause1 = mkClause $ resolveLit : lits1
       litAddedClause2 = mkClause $ opposite resolveLit : literals clause2
-    pure $ StepInst litAddedClause1 litAddedClause2 printSolution extraText
+    pure $ StepInst {
+      clause1 = litAddedClause1,
+      clause2 = litAddedClause2,
+      showAsSet = displayUsingSetNotation,
+      showSolution = printSolution,
+      addText = extraText
+    }
 
 
 
@@ -45,8 +54,8 @@ description StepInst{..} = do
     translate $ do
       german "Betrachten Sie die zwei folgenden Klauseln:"
       english "Consider the two following clauses:"
-    indent $ code $ show clause1
-    indent $ code $ show clause2
+    indent $ code $ show' clause1
+    indent $ code $ show' clause2
     pure ()
   paragraph $ translate $ do
     german "Resolvieren Sie die Klauseln und geben Sie die Resolvente an."
@@ -66,6 +75,10 @@ description StepInst{..} = do
     pure ()
   extra addText
   pure ()
+    where
+      show' clause = if showAsSet
+        then showClauseAsSet clause
+        else show clause
 
 
 verifyStatic :: OutputCapable m => StepInst -> LangM m

--- a/src/LogicTasks/Semantics/Step.hs
+++ b/src/LogicTasks/Semantics/Step.hs
@@ -26,7 +26,7 @@ import LogicTasks.Helpers (clauseKey, example, extra)
 import Util (checkBaseConf, prevent, preventWithHint, tryGen)
 import Control.Monad (when)
 import Formula.Parsing.Delayed (Delayed, withDelayed)
-import Formula.Parsing (Parse(..))
+import Formula.Parsing (clauseFormulaParser, stepAnswerParser, clauseSetParser)
 import Formula.Helpers (showClauseAsSet)
 
 
@@ -106,7 +106,9 @@ start :: StepAnswer
 start = StepAnswer Nothing
 
 partialGrade :: OutputCapable m => StepInst -> Delayed StepAnswer -> LangM m
-partialGrade inst = partialGrade' inst `withDelayed` parser
+partialGrade inst = partialGrade' inst `withDelayed` stepAnswerParser clauseParser
+  where clauseParser | showAsSet inst = clauseSetParser
+                     | otherwise      = clauseFormulaParser
 
 partialGrade' :: OutputCapable m => StepInst -> StepAnswer -> LangM m
 partialGrade' StepInst{..} sol = do
@@ -141,7 +143,9 @@ partialGrade' StepInst{..} sol = do
      extraLiterals = toList (solLits `difference` availLits)
 
 completeGrade :: OutputCapable m => StepInst -> Delayed StepAnswer -> LangM m
-completeGrade inst = completeGrade' inst `withDelayed` parser
+completeGrade inst = completeGrade' inst `withDelayed` stepAnswerParser clauseParser
+  where clauseParser | showAsSet inst = clauseSetParser
+                     | otherwise      = clauseFormulaParser
 
 
 completeGrade' :: OutputCapable m => StepInst -> StepAnswer -> LangM m

--- a/src/LogicTasks/Semantics/Step.hs
+++ b/src/LogicTasks/Semantics/Step.hs
@@ -24,8 +24,8 @@ import Formula.Types (Clause(Clause, literalSet), Literal(..), genClause, litera
 import Formula.Resolution (resolvable, resolve)
 import LogicTasks.Helpers (clauseKey, example, extra)
 import Util (checkBaseConf, prevent, preventWithHint, tryGen)
-import Control.Monad (when, unless, void)
-import Formula.Parsing.Delayed (Delayed, withDelayed, parseDelayedAndThen, complainAboutWrongNotation)
+import Control.Monad (when, unless)
+import Formula.Parsing.Delayed (Delayed, withDelayed, parseDelayedWithAndThen, complainAboutWrongNotation)
 import Formula.Parsing (clauseFormulaParser, stepAnswerParser, clauseSetParser)
 import Formula.Helpers (showClauseAsSet)
 
@@ -119,7 +119,7 @@ start :: StepAnswer
 start = StepAnswer Nothing
 
 partialGrade :: OutputCapable m => StepInst -> Delayed StepAnswer -> LangM m
-partialGrade inst = parseDelayedAndThen complainAboutWrongNotation (void clauseParser) $ partialGrade' inst
+partialGrade inst = parseDelayedWithAndThen (stepAnswerParser clauseParser) complainAboutWrongNotation (pure ()) $ partialGrade' inst
   where clauseParser | usesSetNotation inst = clauseSetParser
                      | otherwise            = clauseFormulaParser
 

--- a/src/LogicTasks/Semantics/Step.hs
+++ b/src/LogicTasks/Semantics/Step.hs
@@ -41,7 +41,7 @@ genStepInst StepConfig{ baseConf = BaseConfig{..}, ..} = do
     pure $ StepInst {
       clause1 = litAddedClause1,
       clause2 = litAddedClause2,
-      showAsSet = displayUsingSetNotation,
+      usesSetNotation = useSetNotation,
       showSolution = printSolution,
       addText = extraText
     }
@@ -76,7 +76,7 @@ description StepInst{..} = do
   extra addText
   pure ()
     where
-      show' clause = if showAsSet
+      show' clause = if usesSetNotation
         then showClauseAsSet clause
         else show clause
 
@@ -107,7 +107,7 @@ start = StepAnswer Nothing
 
 partialGrade :: OutputCapable m => StepInst -> Delayed StepAnswer -> LangM m
 partialGrade inst = partialGrade' inst `withDelayed` stepAnswerParser clauseParser
-  where clauseParser | showAsSet inst = clauseSetParser
+  where clauseParser | usesSetNotation inst = clauseSetParser
                      | otherwise      = clauseFormulaParser
 
 partialGrade' :: OutputCapable m => StepInst -> StepAnswer -> LangM m
@@ -144,7 +144,7 @@ partialGrade' StepInst{..} sol = do
 
 completeGrade :: OutputCapable m => StepInst -> Delayed StepAnswer -> LangM m
 completeGrade inst = completeGrade' inst `withDelayed` stepAnswerParser clauseParser
-  where clauseParser | showAsSet inst = clauseSetParser
+  where clauseParser | usesSetNotation inst = clauseSetParser
                      | otherwise      = clauseFormulaParser
 
 

--- a/src/LogicTasks/Semantics/Step.hs
+++ b/src/LogicTasks/Semantics/Step.hs
@@ -24,8 +24,8 @@ import Formula.Types (Clause(Clause, literalSet), Literal(..), genClause, litera
 import Formula.Resolution (resolvable, resolve)
 import LogicTasks.Helpers (clauseKey, example, extra)
 import Util (checkBaseConf, prevent, preventWithHint, tryGen)
-import Control.Monad (when, unless)
-import Formula.Parsing.Delayed (Delayed, withDelayed)
+import Control.Monad (when, unless, void)
+import Formula.Parsing.Delayed (Delayed, withDelayed, parseDelayedAndThen, complainAboutWrongNotation)
 import Formula.Parsing (clauseFormulaParser, stepAnswerParser, clauseSetParser)
 import Formula.Helpers (showClauseAsSet)
 
@@ -119,9 +119,9 @@ start :: StepAnswer
 start = StepAnswer Nothing
 
 partialGrade :: OutputCapable m => StepInst -> Delayed StepAnswer -> LangM m
-partialGrade inst = partialGrade' inst `withDelayed` stepAnswerParser clauseParser
+partialGrade inst = parseDelayedAndThen complainAboutWrongNotation (void clauseParser) $ partialGrade' inst
   where clauseParser | usesSetNotation inst = clauseSetParser
-                     | otherwise      = clauseFormulaParser
+                     | otherwise            = clauseFormulaParser
 
 partialGrade' :: OutputCapable m => StepInst -> StepAnswer -> LangM m
 partialGrade' StepInst{..} sol = do

--- a/src/LogicTasks/Semantics/Step.hs
+++ b/src/LogicTasks/Semantics/Step.hs
@@ -11,7 +11,7 @@ import Control.OutputCapable.Blocks (
   OutputCapable,
   english,
   german,
-  translate,
+  translate, localise, translations,
   )
 import Data.Maybe (fromJust, isNothing)
 import Data.List (delete)
@@ -24,7 +24,7 @@ import Formula.Types (Clause(Clause, literalSet), Literal(..), genClause, litera
 import Formula.Resolution (resolvable, resolve)
 import LogicTasks.Helpers (clauseKey, example, extra)
 import Util (checkBaseConf, prevent, preventWithHint, tryGen)
-import Control.Monad (when)
+import Control.Monad (when, unless)
 import Formula.Parsing.Delayed (Delayed, withDelayed)
 import Formula.Parsing (clauseFormulaParser, stepAnswerParser, clauseSetParser)
 import Formula.Helpers (showClauseAsSet)
@@ -67,12 +67,25 @@ description StepInst{..} = do
 
   clauseKey
 
-  paragraph $ indent $ do
+  when usesSetNotation $ paragraph $ indent $ do
     translate $ do
-      german "Ein Lösungsversuch könnte beispielsweise so aussehen: "
-      english "A valid solution could look like this: "
-    code "(A, not B or C)"
+      german "Nutzen Sie zur Angabe der Resolvente die Mengennotation! Ein Lösungsversuch könnte beispielsweise so aussehen: "
+      english "Specify the resolvent using set notation! A valid solution could look like this: "
+    translatedCode $ flip localise $ translations $ do
+      german "(A, {nicht B, C})"
+      english "(A, {not B, C})"
     pure ()
+
+  unless usesSetNotation $ paragraph $ indent $ do
+    translate $ do
+      german "Nutzen Sie zur Angabe der Resolvente eine Formel! Ein Lösungsversuch könnte beispielsweise so aussehen: "
+      english "Specify the resolvent using a formula! A valid solution could look like this: "
+    translatedCode $ flip localise $ translations $ do
+      german "(A, nicht B oder C)"
+      english "(A, not B or C)"
+    pure ()
+
+
   extra addText
   pure ()
     where

--- a/test/ResolutionSpec.hs
+++ b/test/ResolutionSpec.hs
@@ -41,6 +41,7 @@ validBoundsResolution = do
     baseConf
   , minSteps
   , printFeedbackImmediately = False
+  , useSetNotation = True
   , printSolution = False
   , extraText = Nothing
   }


### PR DESCRIPTION
Wie in #84 angemerkt wäre es nicht schlecht anhand einer Flag zu bestimmen, ob eine Klausel (oder KNF) in Mengennotation angezeigt werden soll. Dafür habe ich die Flag `displayUsingSetNotation` bei den Aufgabentypen Step und Resolve hinzugefügt. An der letztendlichen Eingabe-Syntax habe ich erstmal nichts geändert. Das wäre natürlich denkbar. Allerdings müsste man dann die `Parse` Instanzen anpassen.