### PR TITLE
Fix solution printout for the Resolve task

### DIFF
--- a/src/Formula/Resolution.hs
+++ b/src/Formula/Resolution.hs
@@ -7,7 +7,7 @@ module Formula.Resolution
        , resolvableWith
        , applySteps
        , computeResSteps
-       , showResStep
+       , showResSteps
        ) where
 
 
@@ -20,7 +20,7 @@ import Test.QuickCheck (Gen,choose,elements,shuffle)
 
 import Formula.Types hiding (Dnf(..), Con(..))
 import Formula.Util
-import Data.List (find, elemIndex)
+import Data.List (find, elemIndex, intercalate)
 import Data.Containers.ListUtils (nubOrd)
 import Text.PrettyPrint.Leijen.Text (Pretty(pretty))
 import Formula.Printing ()
@@ -194,8 +194,9 @@ removeNumberAtEmptyClause res@(Res (a,b,(Clause c,_)))
   | null c = Res (a,b,(Clause c,Nothing))
   | otherwise = res
 
-showResStep :: ResStep -> String
-showResStep = show . pretty . removeNumberAtEmptyClause
+showResSteps :: [ResStep] -> String
+showResSteps steps = "[" ++ intercalate ", " prettyMap ++ "]"
+  where prettyMap = map (show . pretty . removeNumberAtEmptyClause) steps
 
 computeResSteps :: [Clause] -> [ResStep]
 computeResSteps clauses = convertSteps (applyNum clauses reconstructed)

--- a/src/Formula/Resolution.hs
+++ b/src/Formula/Resolution.hs
@@ -20,7 +20,7 @@ import Test.QuickCheck (Gen,choose,elements,shuffle)
 
 import Formula.Types hiding (Dnf(..), Con(..))
 import Formula.Util
-import Data.List (find, elemIndex, intercalate)
+import Data.List (find, elemIndex)
 import Data.Containers.ListUtils (nubOrd)
 import Text.PrettyPrint.Leijen.Text (Pretty(pretty))
 import Formula.Printing ()
@@ -195,8 +195,7 @@ removeNumberAtEmptyClause res@(Res (a,b,(Clause c,_)))
   | otherwise = res
 
 showResSteps :: [ResStep] -> String
-showResSteps steps = "[" ++ intercalate ", " prettyMap ++ "]"
-  where prettyMap = map (show . pretty . removeNumberAtEmptyClause) steps
+showResSteps = show . pretty . map removeNumberAtEmptyClause
 
 computeResSteps :: [Clause] -> [ResStep]
 computeResSteps clauses = convertSteps (applyNum clauses reconstructed)

--- a/src/LogicTasks/Semantics/Resolve.hs
+++ b/src/LogicTasks/Semantics/Resolve.hs
@@ -24,7 +24,7 @@ import Test.QuickCheck (Gen)
 
 import Config (ResolutionConfig(..), ResolutionInst(..), BaseConfig(..))
 import Formula.Util (isEmptyClause, mkCnf, sat)
-import Formula.Resolution (applySteps, genRes, resolvableWith, resolve, showResStep, computeResSteps)
+import Formula.Resolution (applySteps, genRes, resolvableWith, resolve, showResSteps, computeResSteps)
 import Formula.Types (Clause, ResStep(..), literals)
 import LogicTasks.Helpers (example, extra, keyHeading, negationKey)
 import Util (checkBaseConf, prevent, preventWithHint, printWithHint)
@@ -227,7 +227,7 @@ completeGrade ResolutionInst{..} sol = (if isCorrect then id else refuse) $ do
       english "Solution is correct?"
 
     when (showSolution && not isCorrect) $
-      example (show (map showResStep (computeResSteps clauses))) $ do
+      example (showResSteps (computeResSteps clauses)) $ do
         english "A possible solution for this task is:"
         german "Eine mögliche Lösung für die Aufgabe ist:"
 


### PR DESCRIPTION
The solution printout for the `Resolve` tasks had some undesirable escaping of quotation marks. This is now fixed.

A printout looks like this now:
![image](https://github.com/fmidue/logic-tasks/assets/24428341/c92297d2-acae-4e8c-b904-357c0c872b0d)
