### PR TITLE
Remove redundancy at the `Resolve` task

### DIFF
--- a/logic-tasks.cabal
+++ b/logic-tasks.cabal
@@ -58,10 +58,10 @@ library
       ParsingHelpers
       Config
       Formula.Types
+      Formula.Resolution
   other-modules:
       Auxiliary
       Formula.Printing
-      Formula.Resolution
       Formula.Table
       Formula.Util
       LogicTasks.Helpers
@@ -102,6 +102,7 @@ test-suite src-test
       LegalPropositionSpec
       ParsingSpec
       PrologSpec
+      ResolutionSpec
       SubTreeSpec
       SuperfluousBracketsSpec
       SynTreeSpec

--- a/package.yaml
+++ b/package.yaml
@@ -74,6 +74,7 @@ library:
     - ParsingHelpers
     - Config
     - Formula.Types
+    - Formula.Resolution
 
   ghc-options:
     - -Wall

--- a/src/LogicTasks/Semantics/Resolve.hs
+++ b/src/LogicTasks/Semantics/Resolve.hs
@@ -17,9 +17,10 @@ import Control.Monad.Output (
   translations,
   localise,
   yesNo,
+  recoverFrom,
   )
 import Data.List (sort)
-import Data.Maybe (fromJust, isNothing)
+import Data.Maybe (fromJust, fromMaybe, isNothing)
 import Test.QuickCheck (Gen)
 
 import Config (ResolutionConfig(..), ResolutionInst(..), BaseConfig(..))
@@ -27,8 +28,9 @@ import Formula.Util (isEmptyClause, mkCnf, sat)
 import Formula.Resolution (applySteps, genRes, resolvableWith, resolve, showResSteps, computeResSteps)
 import Formula.Types (Clause, ResStep(..), literals)
 import LogicTasks.Helpers (example, extra, keyHeading, negationKey)
-import Util (checkBaseConf, prevent, preventWithHint, printWithHint)
+import Util (checkBaseConf, prevent, preventWithHint)
 import Control.Monad (unless, when)
+import Control.Applicative (Alternative)
 import Data.Foldable.Extra (notNull)
 
 
@@ -157,10 +159,9 @@ verifyQuiz ResolutionConfig{..}
 start :: [ResStep]
 start = []
 
--- Returns (True, ...) when the steps are correct
-gradeSteps :: OutputMonad m => [ResStep] -> [Clause] -> (Bool, LangM m)
-gradeSteps sol clauses = (not incorrect, do
-    printWithHint (notNull noResolveSteps)
+gradeSteps :: OutputMonad m => [ResStep] -> [Clause] -> LangM m
+gradeSteps sol clauses = do
+    preventWithHint (notNull noResolveSteps)
         (translate $ do
           german "Alle Schritte sind gültig?"
           english "All steps are valid?"
@@ -173,19 +174,29 @@ gradeSteps sol clauses = (not incorrect, do
           pure ()
         )
 
-    yesNo (not checkEmptyClause) $
+    prevent checkEmptyClause $
       translate $ do
         german "Letzter Schritt leitet die leere Klausel ab?"
         english "The last step derives the empty clause?"
 
+    preventWithHint (isNothing applied)
+      (translate $ do
+        german "Alle Schritte nutzen vorhandene oder zuvor abgeleitete Klauseln?"
+        english "All steps utilize existing or previously derived clauses?"
+      )
+      (paragraph $ do
+        translate $ do
+          german "Mindestens ein Schritt beinhaltet Klauseln, die weder in der Formel vorhanden sind, noch zuvor abgeleitet wurden."
+          english "At least one step contains clauses that are neither present in the formula nor were previously derived."
+      )
+
     pure ()
-  )
     where
       noResolveSteps = filter (\(c1,c2,r) -> maybe True (\x ->
             fromJust (resolve c1 c2 x) /= r) (resolvableWith c1 c2)) steps
       steps = replaceAll sol $ baseMapping clauses
       checkEmptyClause = null steps || not (isEmptyClause $ third3 $ last steps)
-      incorrect = notNull noResolveSteps || checkEmptyClause
+      applied = applySteps clauses steps
 
 
 partialGrade :: OutputMonad m => ResolutionInst -> [ResStep] -> LangM m
@@ -205,19 +216,8 @@ partialGrade ResolutionInst{..} sol = do
       pure ()
     )
 
-  preventWithHint (isNothing applied)
-    (translate $ do
-      german "Alle Schritte nutzen vorhandene oder zuvor abgeleitete Klauseln?"
-      english "All steps utilize existing or previously derived clauses?"
-    )
-    (paragraph $ do
-      translate $ do
-        german "Mindestens ein Schritt beinhaltet Klauseln, die weder in der Formel vorhanden sind noch zuvor abgeleitet wurden."
-        english "At least one step contains clauses that are neither present in the formula nor were previously derived. "
-    )
-
   when printFeedbackImmediately $ do
-    (if fst stepsGraded then id else refuse) $ snd stepsGraded
+    stepsGraded
 
   pure ()
   where
@@ -227,12 +227,11 @@ partialGrade ResolutionInst{..} sol = do
     stepLits (c1,c2,r) = toList $ unions $ map (fromList . literals) [c1,c2,r]
     wrongLitsSteps = filter (not . all (`member` availLits) . stepLits) steps
     stepsGraded = gradeSteps sol clauses
-    applied = applySteps clauses steps
 
-completeGrade :: OutputMonad m => ResolutionInst -> [ResStep] -> LangM m
+completeGrade :: (OutputMonad m, Alternative m) => ResolutionInst -> [ResStep] -> LangM m
 completeGrade ResolutionInst{..} sol = (if isCorrect then id else refuse) $ do
     unless printFeedbackImmediately $ do
-      snd stepsGraded
+      recoverFrom stepsGraded
 
     yesNo isCorrect $ translate $ do
       german "Lösung ist korrekt?"
@@ -245,8 +244,10 @@ completeGrade ResolutionInst{..} sol = (if isCorrect then id else refuse) $ do
 
     pure ()
   where
+    steps = replaceAll sol $ baseMapping clauses
+    applied = applySteps clauses steps
     stepsGraded = gradeSteps sol clauses
-    isCorrect = fst stepsGraded
+    isCorrect = any isEmptyClause (fromMaybe [] applied)
 
 baseMapping :: [Clause] -> [(Int,Clause)]
 baseMapping xs = zip [1..] $ sort xs

--- a/src/LogicTasks/Semantics/Resolve.hs
+++ b/src/LogicTasks/Semantics/Resolve.hs
@@ -160,8 +160,8 @@ verifyQuiz ResolutionConfig{..}
 start :: [ResStep]
 start = []
 
-gradeSteps :: OutputMonad m => Bool -> [ResStep] -> [Clause] -> LangM m
-gradeSteps appliedIsNothing sol clauses = do
+gradeSteps :: OutputMonad m => [(Clause,Clause,Clause)] -> Bool -> LangM m
+gradeSteps steps appliedIsNothing = do
     preventWithHint (notNull noResolveSteps)
         (translate $ do
           german "Alle Schritte sind gültig?"
@@ -195,7 +195,6 @@ gradeSteps appliedIsNothing sol clauses = do
     where
       noResolveSteps = filter (\(c1,c2,r) -> maybe True (\x ->
             fromJust (resolve c1 c2 x) /= r) (resolvableWith c1 c2)) steps
-      steps = replaceAll sol $ baseMapping clauses
       checkEmptyClause = null steps || not (isEmptyClause $ third3 $ last steps)
 
 
@@ -227,7 +226,7 @@ partialGrade ResolutionInst{..} sol = do
     stepLits (c1,c2,r) = toList $ unions $ map (fromList . literals) [c1,c2,r]
     wrongLitsSteps = filter (not . all (`member` availLits) . stepLits) steps
     applied = applySteps clauses steps
-    stepsGraded = gradeSteps (isNothing applied) sol clauses
+    stepsGraded = gradeSteps steps (isNothing applied)
 
 completeGrade :: (OutputMonad m, Alternative m) => ResolutionInst -> [ResStep] -> LangM m
 completeGrade ResolutionInst{..} sol = (if isCorrect then id else refuse) $ do
@@ -247,7 +246,7 @@ completeGrade ResolutionInst{..} sol = (if isCorrect then id else refuse) $ do
   where
     steps = replaceAll sol $ baseMapping clauses
     applied = applySteps clauses steps
-    stepsGraded = gradeSteps (isNothing applied) sol clauses
+    stepsGraded = gradeSteps steps (isNothing applied)
     isCorrect = any isEmptyClause (fromMaybe [] applied)
 
 baseMapping :: [Clause] -> [(Int,Clause)]

--- a/src/LogicTasks/Semantics/Resolve.hs
+++ b/src/LogicTasks/Semantics/Resolve.hs
@@ -19,12 +19,12 @@ import Control.Monad.Output (
   yesNo,
   )
 import Data.List (sort)
-import Data.Maybe (fromJust)
+import Data.Maybe (fromJust, fromMaybe)
 import Test.QuickCheck (Gen)
 
 import Config (ResolutionConfig(..), ResolutionInst(..), BaseConfig(..))
 import Formula.Util (isEmptyClause, mkCnf, sat)
-import Formula.Resolution (genRes, resolvableWith, resolve, showResStep, computeResSteps)
+import Formula.Resolution (genRes, resolvableWith, resolve, showResStep, computeResSteps, applySteps)
 import Formula.Types (Clause, ResStep(..), literals)
 import LogicTasks.Helpers (example, extra, keyHeading, negationKey)
 import Util (checkBaseConf, prevent, preventWithHint, printWithHint)
@@ -234,7 +234,9 @@ completeGrade ResolutionInst{..} sol = (if isCorrect then id else refuse) $ do
     pure ()
   where
     stepsGraded = gradeSteps sol clauses
-    isCorrect = printFeedbackImmediately || fst stepsGraded
+    steps = replaceAll sol $ baseMapping clauses
+    applied = applySteps clauses steps
+    isCorrect = any isEmptyClause (fromMaybe [] applied)
 
 baseMapping :: [Clause] -> [(Int,Clause)]
 baseMapping xs = zip [1..] $ sort xs

--- a/src/LogicTasks/Semantics/Resolve.hs
+++ b/src/LogicTasks/Semantics/Resolve.hs
@@ -19,12 +19,12 @@ import Control.Monad.Output (
   yesNo,
   )
 import Data.List (sort)
-import Data.Maybe (fromJust, fromMaybe)
+import Data.Maybe (fromJust)
 import Test.QuickCheck (Gen)
 
 import Config (ResolutionConfig(..), ResolutionInst(..), BaseConfig(..))
 import Formula.Util (isEmptyClause, mkCnf, sat)
-import Formula.Resolution (applySteps, genRes, resolvableWith, resolve, showResStep, computeResSteps)
+import Formula.Resolution (genRes, resolvableWith, resolve, showResStep, computeResSteps)
 import Formula.Types (Clause, ResStep(..), literals)
 import LogicTasks.Helpers (example, extra, keyHeading, negationKey)
 import Util (checkBaseConf, prevent, preventWithHint, printWithHint)
@@ -233,10 +233,8 @@ completeGrade ResolutionInst{..} sol = (if isCorrect then id else refuse) $ do
 
     pure ()
   where
-    steps = replaceAll sol $ baseMapping clauses
-    applied = applySteps clauses steps
     stepsGraded = gradeSteps sol clauses
-    isCorrect = any isEmptyClause (fromMaybe [] applied) && (printFeedbackImmediately || fst stepsGraded)
+    isCorrect = printFeedbackImmediately || fst stepsGraded
 
 baseMapping :: [Clause] -> [(Int,Clause)]
 baseMapping xs = zip [1..] $ sort xs

--- a/test/ResolutionSpec.hs
+++ b/test/ResolutionSpec.hs
@@ -43,3 +43,7 @@ spec = do
       let clauses = [justA, notAnotB, notAjustB]
       let steps = [(justA, notAnotB, justB)]
       isNothing $ applySteps clauses steps
+    it "should return Nothing if some steps use unavailable clauses" $ do
+      let clauses = [justB, notAnotB]
+      let steps = [(justB, notB, emptyClause)]
+      isNothing $ applySteps clauses steps

--- a/test/ResolutionSpec.hs
+++ b/test/ResolutionSpec.hs
@@ -1,0 +1,45 @@
+module ResolutionSpec where
+
+import Test.Hspec
+import Formula.Resolution (applySteps)
+import Data.Maybe (isJust, fromJust, isNothing)
+import Formula.Types (Clause(Clause), Literal (Literal,Not))
+import qualified Data.Set
+
+justA :: Clause
+justA = Clause (Data.Set.fromList [Literal 'A'])
+
+notAnotB :: Clause
+notAnotB = Clause (Data.Set.fromList [Not 'A', Not 'B'])
+
+notAjustB :: Clause
+notAjustB = Clause (Data.Set.fromList [Not 'A', Literal 'B'])
+
+notB :: Clause
+notB = Clause (Data.Set.fromList [Not 'B'])
+
+justB :: Clause
+justB = Clause (Data.Set.fromList [Literal 'B'])
+
+emptyClause :: Clause
+emptyClause = Clause Data.Set.empty
+
+spec :: Spec
+spec = do
+  describe "applySteps" $ do
+    it "should return a Just value if there are no clauses" $
+      isJust $ applySteps [] []
+    it "should return the original list of clauses if there are no steps to apply" $ do
+      let clauses = [Clause (Data.Set.fromList [Literal 'A'])]
+      fromJust (applySteps clauses []) == clauses
+    it "should return the correct list of clauses if the steps are able to be applied" $ do
+      let clauses = [justA, notAnotB, notAjustB]
+      let steps = [(justA, notAnotB, notB)
+                 , (justA, notAjustB, justB)
+                 , (notB, justB, emptyClause)]
+      let result = fromJust (applySteps clauses steps)
+      notB `elem` result && justB `elem` result && emptyClause `elem` result
+    it "should return Nothing if some step is invalid" $ do
+      let clauses = [justA, notAnotB, notAjustB]
+      let steps = [(justA, notAnotB, justB)]
+      isNothing $ applySteps clauses steps


### PR DESCRIPTION
As mentioned in #101 `completeGrade` had some redundancy. This is probably a leftover from when I was not aware that `completeGrade` won't be evaluated when `partialGrade` already failed.

 I added some tests for `applySteps` (even though we don't use it any more). 

I also tried to add tests for `gradeSteps` which was not possible due to errors regarding `OutputMonad`
![image](https://github.com/fmidue/logic-tasks/assets/24428341/a6227c9c-cd8e-46b8-974b-7fc1fb2ee23e)
