### PR TITLE
Eingabelegende an `allowArrowOperators` anpassen

### DIFF
--- a/src/LogicTasks/Helpers.hs
+++ b/src/LogicTasks/Helpers.hs
@@ -86,12 +86,6 @@ basicOpKey = do
   orKey
   pure()
 
-fullKey :: OutputMonad m => LangM m
-fullKey = do
-  basicOpKey
-  arrowsKey
-  pure ()
-
 keyHeading :: OutputMonad m => LangM m
 keyHeading =
   paragraph $ translate $ do

--- a/src/LogicTasks/Syntax/SimplestFormula.hs
+++ b/src/LogicTasks/Syntax/SimplestFormula.hs
@@ -9,7 +9,7 @@ import Control.Monad.Output (LangM, OutputMonad, english, german, paragraph, tra
 import Data.List (nub, sort)
 import Data.Maybe (isNothing, fromJust)
 
-import LogicTasks.Helpers (basicOpKey, example, extra, focus, instruct, reject)
+import LogicTasks.Helpers (basicOpKey, example, extra, focus, instruct, reject, arrowsKey)
 import Tasks.SuperfluousBrackets.Config (
     checkSuperfluousBracketsConfig,
     SuperfluousBracketsConfig(..),
@@ -54,6 +54,7 @@ description SuperfluousBracketsInst{..} = do
       german "Sie können dafür die Ausgangsformel in die Abgabe kopieren und unnötige Klammern entfernen, oder die folgenden Schreibweisen nutzen:"
       english "You can copy the original formula into the solution box and remove unnecessary brackets or use the following syntax:"
     basicOpKey
+    when arrowOperatorsAllowed arrowsKey
 
     extra addText
     pure ()

--- a/src/LogicTasks/Syntax/SubTreeSet.hs
+++ b/src/LogicTasks/Syntax/SubTreeSet.hs
@@ -10,7 +10,7 @@ import Data.List (nub, sort)
 import Data.Set (fromList, isSubsetOf, toList)
 import qualified Data.Set (map)
 import Data.Maybe (isNothing, fromJust)
-import LogicTasks.Helpers (example, extra, focus, fullKey, instruct, keyHeading, reject)
+import LogicTasks.Helpers (example, extra, focus, instruct, keyHeading, reject, basicOpKey, arrowsKey)
 import Tasks.SubTree.Config (checkSubTreeConfig, SubTreeInst(..), SubTreeConfig(..))
 import Trees.Types (FormulaAnswer(..))
 import Trees.Print (display, transferToPicture)
@@ -46,7 +46,8 @@ description SubTreeInst{..} = do
       german "Ist z.B. ¬(A ∨ (B ∧ C)) die gegebene Formel und es werden zwei Teilformeln gesucht, dann ist die folgende Lösung korrekt:"
 
     keyHeading
-    fullKey
+    basicOpKey
+    when arrowOperatorsAllowed arrowsKey
 
     extra addText
     pure ()

--- a/src/LogicTasks/Syntax/TreeToFormula.hs
+++ b/src/LogicTasks/Syntax/TreeToFormula.hs
@@ -19,7 +19,7 @@ import Data.Digest.Pure.SHA (sha1, showDigest)
 import Data.Maybe (fromJust, isNothing)
 import Image.LaTeX.Render (FormulaOptions(..), SVG, defaultEnv, imageForFormula)
 
-import LogicTasks.Helpers (cacheIO, extra, fullKey, instruct, keyHeading, reject, example)
+import LogicTasks.Helpers (cacheIO, extra, instruct, keyHeading, reject, example, basicOpKey, arrowsKey)
 import Tasks.SynTree.Config (checkSynTreeConfig, SynTreeConfig)
 import Trees.Types (TreeFormulaAnswer(..))
 import Formula.Util (isSemanticEqual)
@@ -51,7 +51,8 @@ description path TreeToFormulaInst{..} = do
       german "Hinweise: Es muss die exakte Formel des Syntaxbaums angegeben werden. Andere, selbst zu dieser Formel semantisch äquivalente Formeln sind keine korrekte Lösung! Auch dürfen Sie bei dieser Aufgabe nicht Assoziativität verwenden, um Klammern einzusparen."
 
     keyHeading
-    fullKey
+    basicOpKey
+    when arrowOperatorsAllowed arrowsKey
 
     extra addText
     pure ()

--- a/src/Tasks/SubTree/Config.hs
+++ b/src/Tasks/SubTree/Config.hs
@@ -71,6 +71,7 @@ data SubTreeInst =
     { tree :: SynTree BinOp Char
     , correctTrees :: Set (SynTree BinOp Char)
     , minInputTrees :: Integer
+    , arrowOperatorsAllowed :: Bool
     , showSolution :: Bool
     , addText :: Maybe (Map Language String)
     } deriving (Show,Generic)

--- a/src/Tasks/SubTree/Quiz.hs
+++ b/src/Tasks/SubTree/Quiz.hs
@@ -33,6 +33,7 @@ generateSubTreeInst SubTreeConfig {syntaxTreeConfig = SynTreeConfig {..}, ..} = 
       { tree
       , minInputTrees = minSubTrees
       , correctTrees = correctTrees
+      , arrowOperatorsAllowed = allowArrowOperators
       , showSolution = printSolution
       , addText = extraText
       }

--- a/src/Tasks/SuperfluousBrackets/Config.hs
+++ b/src/Tasks/SuperfluousBrackets/Config.hs
@@ -72,6 +72,7 @@ data SuperfluousBracketsInst =
       tree :: SynTree BinOp Char
     , stringWithSuperfluousBrackets :: String
     , simplestString :: String
+    , arrowOperatorsAllowed :: Bool
     , showSolution :: Bool
     , addText :: Maybe (Map Language String)
     } deriving (Show,Generic)

--- a/src/Tasks/SuperfluousBrackets/Quiz.hs
+++ b/src/Tasks/SuperfluousBrackets/Quiz.hs
@@ -33,6 +33,7 @@ generateSuperfluousBracketsInst SuperfluousBracketsConfig {syntaxTreeConfig = Sy
       { tree
       , stringWithSuperfluousBrackets
       , simplestString = simplestDisplay tree
+      , arrowOperatorsAllowed = allowArrowOperators
       , showSolution = printSolution
       , addText = extraText
       }

--- a/src/Tasks/TreeToFormula/Config.hs
+++ b/src/Tasks/TreeToFormula/Config.hs
@@ -44,6 +44,7 @@ data TreeToFormulaInst = TreeToFormulaInst {
                , latexImage :: String
                , correct :: String
                , addExtraHintsOnSemanticEquivalence :: Bool
+               , arrowOperatorsAllowed :: Bool
                , addText :: Maybe (Map Language String)
                , showSolution :: Bool
                }

--- a/src/Tasks/TreeToFormula/Quiz.hs
+++ b/src/Tasks/TreeToFormula/Quiz.hs
@@ -30,6 +30,7 @@ generateTreeToFormulaInst TreeToFormulaConfig {syntaxTreeConfig = SynTreeConfig 
       , latexImage = transferToPicture tree
       , correct = display tree
       , addExtraHintsOnSemanticEquivalence = extraHintsOnSemanticEquivalence
+      , arrowOperatorsAllowed = allowArrowOperators
       , addText = extraText
       , showSolution = printSolution
       }


### PR DESCRIPTION
Wie in #110 beschrieben passt sich die Eingabelegende nun an die Config-Option `allowArrowOperators` an.