### PR TITLE
Fix current test failure

### DIFF
--- a/logic-tasks.cabal
+++ b/logic-tasks.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -39,6 +39,7 @@ library
       Tasks.LegalProposition.PrintIllegal
       Tasks.LegalProposition.PrintBracket
       Tasks.LegalProposition.Quiz
+      Tasks.LegalProposition.Helpers
       Tasks.SuperfluousBrackets.Config
       Tasks.SuperfluousBrackets.Parsing
       Tasks.SuperfluousBrackets.PrintSuperfluousBrackets

--- a/package.yaml
+++ b/package.yaml
@@ -55,6 +55,7 @@ library:
     - Tasks.LegalProposition.PrintIllegal
     - Tasks.LegalProposition.PrintBracket
     - Tasks.LegalProposition.Quiz
+    - Tasks.LegalProposition.Helpers
     - Tasks.SuperfluousBrackets.Config
     - Tasks.SuperfluousBrackets.Parsing
     - Tasks.SuperfluousBrackets.PrintSuperfluousBrackets

--- a/src/Tasks/LegalProposition/Config.hs
+++ b/src/Tasks/LegalProposition/Config.hs
@@ -20,6 +20,7 @@ import LogicTasks.Helpers (reject)
 import Trees.Helpers (maxLeavesForNodes)
 import Tasks.SynTree.Config(SynTreeConfig(..), checkSynTreeConfig, defaultSynTreeConfig)
 import Trees.Types (SynTree, BinOp)
+import Tasks.LegalProposition.Helpers (formulaAmount)
 
 
 
@@ -53,7 +54,7 @@ checkLegalPropositionConfig config@LegalPropositionConfig {..} =
 
 
 checkAdditionalConfig :: OutputMonad m => LegalPropositionConfig ->LangM m
-checkAdditionalConfig LegalPropositionConfig {syntaxTreeConfig = SynTreeConfig {..}, formulas, illegals, bracketFormulas}
+checkAdditionalConfig config@LegalPropositionConfig {syntaxTreeConfig = SynTreeConfig {..}, formulas, illegals, bracketFormulas}
     | minNodes < 3 = reject $ do
         english "form A and ~A is meaningless in this kind of issue"
         german "Minimale Anzahl an Blättern unter 3 kann nur triviale Aufgaben erzeugen."
@@ -73,6 +74,9 @@ checkAdditionalConfig LegalPropositionConfig {syntaxTreeConfig = SynTreeConfig {
       = reject $ do
         english "Settings may result in extremely large formulas."
         german "Einstellungen führen zu extrem großen Formeln."
+    | formulaAmount (syntaxTreeConfig config) < fromIntegral formulas = reject $ do
+      english "Settings cannot ensure provided amount of formulas."
+      german "Einstellungen können nicht die Anzahl der geforderten Formeln erfüllen."
     | otherwise = pure()
 
 

--- a/src/Tasks/LegalProposition/Config.hs
+++ b/src/Tasks/LegalProposition/Config.hs
@@ -74,7 +74,7 @@ checkAdditionalConfig config@LegalPropositionConfig {syntaxTreeConfig = SynTreeC
       = reject $ do
         english "Settings may result in extremely large formulas."
         german "Einstellungen führen zu extrem großen Formeln."
-    | formulaAmount (syntaxTreeConfig config) < fromIntegral formulas = reject $ do
+    | formulaAmount (syntaxTreeConfig config) < formulas = reject $ do
       english "Settings cannot ensure provided amount of formulas."
       german "Einstellungen können nicht die Anzahl der geforderten Formeln erfüllen."
     | otherwise = pure()

--- a/src/Tasks/LegalProposition/Helpers.hs
+++ b/src/Tasks/LegalProposition/Helpers.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE RecordWildCards #-}
+module Tasks.LegalProposition.Helpers where
+import Tasks.SynTree.Config (SynTreeConfig (..))
+import Trees.Types (BinOp)
+
+formulaAmount :: SynTreeConfig -> Int
+formulaAmount SynTreeConfig{..} =
+  (if allowArrowOperators then length [minBound..maxBound :: BinOp] else 2)
+    ^ ((maxNodes - 1) `div` 2 - minUniqueBinOperators + 1)

--- a/src/Tasks/LegalProposition/Helpers.hs
+++ b/src/Tasks/LegalProposition/Helpers.hs
@@ -3,7 +3,7 @@ module Tasks.LegalProposition.Helpers where
 import Tasks.SynTree.Config (SynTreeConfig (..))
 import Trees.Types (BinOp)
 
-formulaAmount :: SynTreeConfig -> Int
+formulaAmount :: SynTreeConfig -> Integer
 formulaAmount SynTreeConfig{..} =
-  (if allowArrowOperators then length [minBound..maxBound :: BinOp] else 2)
+  (if allowArrowOperators then fromIntegral (length [minBound..maxBound :: BinOp]) else 2)
     ^ ((maxNodes - 1) `div` 2 - minUniqueBinOperators + 1)

--- a/src/Tasks/SynTree/Config.hs
+++ b/src/Tasks/SynTree/Config.hs
@@ -116,4 +116,7 @@ checkSynTreeConfig SynTreeConfig {..}
     | not allowArrowOperators && minUniqueBinOperators > 2 = reject $ do
         english "This number of unique operators cannot be reached with allowArrowOperators = False ."
         german "Die angegebene Anzahl der unterschiedlichen Operatoren kann mit allowArrowOperators = False nicht erreicht werden."
+    | minDepth <= minUniqueBinOperators = reject $ do
+        english "The minimal depth is incompatible with the minimal amount of unique operators."
+        german "Die minimale Tiefe ist mit der minimalen Anzahl an unterschiedlichen Operatoren inkompatibel."
     | otherwise = pure()

--- a/src/Tasks/SynTree/Config.hs
+++ b/src/Tasks/SynTree/Config.hs
@@ -81,6 +81,9 @@ checkSynTreeConfig SynTreeConfig {..}
     | minNodes < minAmountOfUniqueAtoms * 2 - 1 = reject $ do
         english "Your minimum number of nodes does not permit enough leaves for all desired literals."
         german "Minimale Anzahl der Knoten ist zu niedrig um alle Literale zu verwenden."
+    | minNodes <= 2 * minUniqueBinOperators = reject $ do
+        english "The minimal number of nodes is incompatible with the minimal number of unique operators"
+        german "Die minimale Anzahl der Knoten erlaubt nicht die minimale Anzahl an unterschiedlichen Operatoren"
     | minDepth < 1 = reject $ do
         english "Minimal depth must be positive"
         german "Minimale Tiefe muss positiv sein."

--- a/src/Tasks/SynTree/Config.hs
+++ b/src/Tasks/SynTree/Config.hs
@@ -15,7 +15,7 @@ import Data.Char (isLetter)
 import GHC.Generics (Generic)
 
 import LogicTasks.Helpers (reject)
-import Trees.Helpers (maxNodesForDepth)
+import Trees.Helpers (maxNodesForDepth, maxDepthForNodes)
 import Trees.Types (BinOp)
 
 
@@ -108,10 +108,3 @@ checkSynTreeConfig SynTreeConfig {..}
         english "This number of unique operators cannot be reached with allowArrowOperators = False ."
         german "Die angegebene Anzahl der unterschiedlichen Operatoren kann mit allowArrowOperators = False nicht erreicht werden."
     | otherwise = pure()
-
-maxDepthForNodes :: Integer -> Integer -> Integer
-maxDepthForNodes maxConsecutiveNegations nodes =
-  let
-    (result, rest) = (nodes - 1) `divMod` (maxConsecutiveNegations + 2)
-  in
-    1 + result * (maxConsecutiveNegations + 1) + min maxConsecutiveNegations rest

--- a/src/Trees/Helpers.hs
+++ b/src/Trees/Helpers.hs
@@ -11,6 +11,7 @@ module Trees.Helpers
     minDepthForNodes,
     maxLeavesForNodes,
     maxNodesForDepth,
+    maxDepthForNodes,
     noSameSubTree,
     sameAssociativeOperatorAdjacent,
     similarExist,
@@ -88,6 +89,13 @@ maxNodesForDepth depth = 2 ^ depth - 1
 
 maxLeavesForNodes :: Integer -> Integer
 maxLeavesForNodes nodes = (nodes + 1) `div` 2
+
+maxDepthForNodes :: Integer -> Integer -> Integer
+maxDepthForNodes maxConsecutiveNegations nodes =
+  let
+    (result, rest) = (nodes - 1) `divMod` (maxConsecutiveNegations + 2)
+  in
+    1 + result * (maxConsecutiveNegations + 1) + min maxConsecutiveNegations rest
 
 sameAssociativeOperatorAdjacent :: SynTree BinOp c -> Bool
 sameAssociativeOperatorAdjacent (Leaf _) = False

--- a/test/LegalPropositionSpec.hs
+++ b/test/LegalPropositionSpec.hs
@@ -74,7 +74,7 @@ spec = do
                       forAll (deleteSpaces <$> illegalDisplay synTree) $
                       all (\c -> c `elem` "()∧∨¬<=>" || isLetter c)
         it "the string after illegalDisplay cannot be parsed" $
-            forAll validBoundsSynTree $ \SynTreeConfig {..} ->
+            within timeout $ forAll validBoundsSynTree $ \SynTreeConfig {..} ->
                 forAll
                   (genSynTree
                     (minNodes, maxNodes)
@@ -89,7 +89,7 @@ spec = do
                       forAll (illegalDisplay synTree) $ \str -> isLeft (formulaParse str)
     describe "bracket display" $ do
         it "the String after bracketDisplay just add a bracket " $
-            forAll validBoundsSynTree $ \SynTreeConfig {..} ->
+            within timeout $ forAll validBoundsSynTree $ \SynTreeConfig {..} ->
                 forAll
                   (genSynTree
                     (minNodes, maxNodes)
@@ -103,7 +103,7 @@ spec = do
                   ) $ \synTree ->
                       forAll (bracketDisplay synTree) $ \str -> length str == length (display synTree) + 2
         it "the String can be parsed by formulaParse" $
-            forAll validBoundsSynTree $ \SynTreeConfig {..} ->
+            within timeout $ forAll validBoundsSynTree $ \SynTreeConfig {..} ->
                 forAll
                   (genSynTree
                     (minNodes, maxNodes)
@@ -117,7 +117,7 @@ spec = do
                   ) $ \synTree ->
                       forAll (bracketDisplay synTree) $ \str -> formulaParse str == Right synTree
         it "the String remove all brackets should same with display remove all brackets" $
-            forAll validBoundsSynTree $ \SynTreeConfig {..} ->
+            within timeout $ forAll validBoundsSynTree $ \SynTreeConfig {..} ->
                 forAll
                   (genSynTree
                     (minNodes, maxNodes)

--- a/test/LegalPropositionSpec.hs
+++ b/test/LegalPropositionSpec.hs
@@ -31,7 +31,7 @@ import Control.Monad.Output.Generic (evalLangM)
 
 validBoundsLegalProposition :: Gen LegalPropositionConfig
 validBoundsLegalProposition = do
-    syntaxTreeConfig@SynTreeConfig {..}  <- validBoundsSynTree `suchThat` ((3 <=) . minNodes)
+    syntaxTreeConfig@SynTreeConfig {..}  <- validBoundsSynTree `suchThat` ((15 <=) . minNodes)
     let leaves = maxLeavesForNodes maxNodes
     formulas <- choose (1, min 15 $ if allowArrowOperators then 4 else 2 ^ (maxNodes - leaves))
     illegals <- choose (0, formulas)

--- a/test/LegalPropositionSpec.hs
+++ b/test/LegalPropositionSpec.hs
@@ -20,7 +20,6 @@ import Tasks.LegalProposition.Quiz (generateLegalPropositionInst)
 import Tasks.SynTree.Config (SynTreeConfig(..))
 import Trees.Parsing (formulaParse)
 import Trees.Generate (genSynTree)
-import Trees.Helpers (maxLeavesForNodes)
 import SynTreeSpec (validBoundsSynTree)
 import Trees.Print (display)
 import TestHelpers (deleteBrackets, deleteSpaces)
@@ -28,12 +27,13 @@ import Control.Monad.Output (LangM)
 import Data.Maybe (isJust)
 import Control.Monad.Identity (Identity(runIdentity))
 import Control.Monad.Output.Generic (evalLangM)
+import Tasks.LegalProposition.Helpers (formulaAmount)
 
 validBoundsLegalProposition :: Gen LegalPropositionConfig
 validBoundsLegalProposition = do
+    formulas <- choose (1, 15)
     syntaxTreeConfig@SynTreeConfig {..}  <- validBoundsSynTree `suchThat` ((15 <=) . minNodes)
-    let leaves = maxLeavesForNodes maxNodes
-    formulas <- choose (1, min 15 $ if allowArrowOperators then 4 else 2 ^ (maxNodes - leaves))
+      `suchThat` \cfg -> formulaAmount cfg >= fromIntegral formulas
     illegals <- choose (0, formulas)
     bracketFormulas <- choose (0, formulas - illegals)
     return $ LegalPropositionConfig

--- a/test/LegalPropositionSpec.hs
+++ b/test/LegalPropositionSpec.hs
@@ -59,29 +59,29 @@ spec = do
           isJust $ runIdentity $ evalLangM (checkLegalPropositionConfig legalPropConfig :: LangM Maybe)
     describe "illegalDisplay" $ do
         it "at least creates actual formula symbols" $
-            within timeout $ forAll validBoundsSynTree $ \synTreeConfig@SynTreeConfig {..} ->
+            within timeout $ forAll validBoundsSynTree $ \synTreeConfig ->
                 forAll
                   (genSynTree synTreeConfig) $ \synTree ->
                       forAll (deleteSpaces <$> illegalDisplay synTree) $
                       all (\c -> c `elem` "()∧∨¬<=>" || isLetter c)
         it "the string after illegalDisplay cannot be parsed" $
-            within timeout $ forAll validBoundsSynTree $ \synTreeConfig@SynTreeConfig {..} ->
+            within timeout $ forAll validBoundsSynTree $ \synTreeConfig ->
                 forAll
                   (genSynTree synTreeConfig) $ \synTree ->
                       forAll (illegalDisplay synTree) $ \str -> isLeft (formulaParse str)
     describe "bracket display" $ do
         it "the String after bracketDisplay just add a bracket " $
-            within timeout $ forAll validBoundsSynTree $ \synTreeConfig@SynTreeConfig {..} ->
+            within timeout $ forAll validBoundsSynTree $ \synTreeConfig ->
                 forAll
                   (genSynTree synTreeConfig) $ \synTree ->
                       forAll (bracketDisplay synTree) $ \str -> length str == length (display synTree) + 2
         it "the String can be parsed by formulaParse" $
-            within timeout $ forAll validBoundsSynTree $ \synTreeConfig@SynTreeConfig {..} ->
+            within timeout $ forAll validBoundsSynTree $ \synTreeConfig ->
                 forAll
                   (genSynTree synTreeConfig) $ \synTree ->
                       forAll (bracketDisplay synTree) $ \str -> formulaParse str == Right synTree
         it "the String remove all brackets should same with display remove all brackets" $
-            within timeout $ forAll validBoundsSynTree $ \synTreeConfig@SynTreeConfig {..} ->
+            within timeout $ forAll validBoundsSynTree $ \synTreeConfig ->
                 forAll
                   (genSynTree synTreeConfig) $ \synTree ->
                       forAll (bracketDisplay synTree) $ \str -> deleteBrackets str == deleteBrackets (display synTree)

--- a/test/LegalPropositionSpec.hs
+++ b/test/LegalPropositionSpec.hs
@@ -9,7 +9,11 @@ import Data.Char (isLetter)
 import Test.Hspec (Spec, describe, it)
 import Test.QuickCheck (Gen, choose, forAll, suchThat, within)
 
-import Tasks.LegalProposition.Config (LegalPropositionConfig (..), LegalPropositionInst(..), checkLegalPropositionConfig, defaultLegalPropositionConfig)
+import Tasks.LegalProposition.Config (
+  LegalPropositionConfig (..),
+  LegalPropositionInst(..),
+  checkLegalPropositionConfig,
+  defaultLegalPropositionConfig)
 import Tasks.LegalProposition.PrintIllegal (illegalDisplay)
 import Tasks.LegalProposition.PrintBracket (bracketDisplay,)
 import Tasks.LegalProposition.Quiz (generateLegalPropositionInst)

--- a/test/LegalPropositionSpec.hs
+++ b/test/LegalPropositionSpec.hs
@@ -33,7 +33,7 @@ validBoundsLegalProposition :: Gen LegalPropositionConfig
 validBoundsLegalProposition = do
     formulas <- choose (1, 15)
     syntaxTreeConfig@SynTreeConfig {..}  <- validBoundsSynTree
-      `suchThat` \cfg -> formulaAmount cfg >= fromIntegral formulas
+      `suchThat` \cfg -> formulaAmount cfg >= formulas
     illegals <- choose (0, formulas)
     bracketFormulas <- choose (0, formulas - illegals)
     return $ LegalPropositionConfig

--- a/test/LegalPropositionSpec.hs
+++ b/test/LegalPropositionSpec.hs
@@ -32,7 +32,7 @@ import Tasks.LegalProposition.Helpers (formulaAmount)
 validBoundsLegalProposition :: Gen LegalPropositionConfig
 validBoundsLegalProposition = do
     formulas <- choose (1, 15)
-    syntaxTreeConfig@SynTreeConfig {..}  <- validBoundsSynTree `suchThat` ((15 <=) . minNodes)
+    syntaxTreeConfig@SynTreeConfig {..}  <- validBoundsSynTree
       `suchThat` \cfg -> formulaAmount cfg >= fromIntegral formulas
     illegals <- choose (0, formulas)
     bracketFormulas <- choose (0, formulas - illegals)

--- a/test/SubTreeSpec.hs
+++ b/test/SubTreeSpec.hs
@@ -9,7 +9,7 @@ import Data.List.Extra (isInfixOf )
 import Data.Set (fromList, size, toList)
 import qualified Data.Set (map)
 
-import Tasks.SubTree.Config (SubTreeConfig(..), SubTreeInst(..))
+import Tasks.SubTree.Config (SubTreeConfig(..), SubTreeInst(..), checkSubTreeConfig, defaultSubTreeConfig)
 import Tasks.SubTree.Quiz (generateSubTreeInst)
 import Trees.Helpers (allNotLeafSubTrees, maxLeavesForNodes)
 import Tasks.SynTree.Config (SynTreeConfig(..),)
@@ -19,6 +19,10 @@ import Trees.Parsing ()
 import Trees.Types (SynTree, BinOp, PropFormula)
 import SynTreeSpec (validBoundsSynTree)
 import Formula.Parsing (Parse(parser))
+import Control.Monad.Output (LangM)
+import Data.Maybe (isJust)
+import Control.Monad.Identity (Identity(runIdentity))
+import Control.Monad.Output.Generic (evalLangM)
 
 validBoundsSubTree :: Gen SubTreeConfig
 validBoundsSubTree = do
@@ -36,6 +40,12 @@ validBoundsSubTree = do
 
 spec :: Spec
 spec = do
+  describe "config" $ do
+      it "default config should pass config check" $
+        isJust $ runIdentity $ evalLangM (checkSubTreeConfig defaultSubTreeConfig :: LangM Maybe)
+      it "validBoundsSubTree should generate a valid config" $
+        forAll validBoundsSubTree $ \subTreeConfig ->
+          isJust $ runIdentity $ evalLangM (checkSubTreeConfig subTreeConfig :: LangM Maybe)
   describe "generateSubTreeInst" $ do
     it "parse should works well" $
       forAll validBoundsSubTree $ \subTreeConfig ->

--- a/test/SuperfluousBracketsSpec.hs
+++ b/test/SuperfluousBracketsSpec.hs
@@ -9,7 +9,11 @@ import Test.Hspec (Spec, describe, it)
 import Text.Parsec (parse)
 
 import Tasks.SuperfluousBrackets.Quiz (generateSuperfluousBracketsInst)
-import Tasks.SuperfluousBrackets.Config(SuperfluousBracketsConfig(..), SuperfluousBracketsInst(..), checkSuperfluousBracketsConfig, defaultSuperfluousBracketsConfig)
+import Tasks.SuperfluousBrackets.Config(
+  SuperfluousBracketsConfig(..),
+  SuperfluousBracketsInst(..),
+  checkSuperfluousBracketsConfig,
+  defaultSuperfluousBracketsConfig)
 import Tasks.SynTree.Config (SynTreeConfig(..))
 import SynTreeSpec (validBoundsSynTree)
 import Trees.Types (SynTree(..), BinOp(..), PropFormula)

--- a/test/SuperfluousBracketsSpec.hs
+++ b/test/SuperfluousBracketsSpec.hs
@@ -30,7 +30,7 @@ import Control.Monad.Output.Generic (evalLangM)
 
 validBoundsSuperfluousBrackets :: Gen SuperfluousBracketsConfig
 validBoundsSuperfluousBrackets = do
-    syntaxTreeConfig@SynTreeConfig {..} <- validBoundsSynTree `suchThat` ((5<=) . minNodes)
+    syntaxTreeConfig@SynTreeConfig {..} <- validBoundsSynTree `suchThat` ((8<=) . minNodes)
     superfluousBracketPairs <- choose (1, minNodes `div` 2)
     return $ SuperfluousBracketsConfig
         {

--- a/test/SuperfluousBracketsSpec.hs
+++ b/test/SuperfluousBracketsSpec.hs
@@ -9,7 +9,7 @@ import Test.Hspec (Spec, describe, it)
 import Text.Parsec (parse)
 
 import Tasks.SuperfluousBrackets.Quiz (generateSuperfluousBracketsInst)
-import Tasks.SuperfluousBrackets.Config(SuperfluousBracketsConfig(..), SuperfluousBracketsInst(..))
+import Tasks.SuperfluousBrackets.Config(SuperfluousBracketsConfig(..), SuperfluousBracketsInst(..), checkSuperfluousBracketsConfig, defaultSuperfluousBracketsConfig)
 import Tasks.SynTree.Config (SynTreeConfig(..))
 import SynTreeSpec (validBoundsSynTree)
 import Trees.Types (SynTree(..), BinOp(..), PropFormula)
@@ -23,6 +23,10 @@ import Trees.Parsing(formulaParse)
 import TestHelpers (deleteBrackets)
 import Trees.Generate (genSynTree)
 import Formula.Parsing (Parse(parser))
+import Control.Monad.Output (LangM)
+import Data.Maybe (isJust)
+import Control.Monad.Identity (Identity(runIdentity))
+import Control.Monad.Output.Generic (evalLangM)
 
 validBoundsSuperfluousBrackets :: Gen SuperfluousBracketsConfig
 validBoundsSuperfluousBrackets = do
@@ -38,6 +42,12 @@ validBoundsSuperfluousBrackets = do
 
 spec :: Spec
 spec = do
+    describe "config" $ do
+      it "default config should pass config check" $
+        isJust $ runIdentity $ evalLangM (checkSuperfluousBracketsConfig defaultSuperfluousBracketsConfig :: LangM Maybe)
+      it "validBoundsSubTree should generate a valid config" $
+        forAll validBoundsSuperfluousBrackets $ \superfluousBracketsConfig ->
+          isJust $ runIdentity $ evalLangM (checkSuperfluousBracketsConfig superfluousBracketsConfig :: LangM Maybe)
     describe "sameAssociativeOperatorAdjacent" $ do
         it "should return false if there are no two \\/s or two /\\s as neighbors" $
             not $ sameAssociativeOperatorAdjacent (Binary Or (Leaf 'a') (Not (Binary Or (Leaf 'a') (Leaf 'c'))))

--- a/test/SynTreeSpec.hs
+++ b/test/SynTreeSpec.hs
@@ -43,7 +43,7 @@ validBoundsSynTree = do
     \maxNodes' -> (maxConsecutiveNegations /= 0 || odd maxNodes')
       && maxDepth <= maxDepthForNodes maxConsecutiveNegations maxNodes'
   let availableBinOpsCount = if allowArrowOperators then fromIntegral $ length [minBound .. maxBound :: BinOp] else 2
-  minUniqueBinOperators <- choose (1, minimum [maxDepth - 1, availableBinOpsCount, (minNodes - 1) `div` 2])
+  minUniqueBinOperators <- choose (1, minimum [minDepth - 1, availableBinOpsCount, (minNodes - 1) `div` 2])
   return $ SynTreeConfig {
     maxNodes,
     minNodes,

--- a/test/SynTreeSpec.hs
+++ b/test/SynTreeSpec.hs
@@ -104,6 +104,10 @@ spec = do
       forAll validBoundsSynTree $ \synTreeConfig@SynTreeConfig {..} ->
         forAll (genSynTree synTreeConfig) $ \tree -> not (replicate (fromIntegral maxConsecutiveNegations + 1) '~'
                     `isInfixOf` deleteSpaces (display tree))
+    it "should generate a random SyntaxTree with fixed nodes and depth" $
+      forAll (validBoundsSynTree `suchThat` \cfg -> minNodes cfg == maxNodes cfg && minDepth cfg == maxDepth cfg) $
+        \synTreeConfig@SynTreeConfig {..} -> forAll (genSynTree synTreeConfig) $ \synTree ->
+            treeDepth synTree == maxDepth && treeNodes synTree == maxNodes
   describe "ToSAT instance" $ do
     it "should correctly convert Leaf" $
       convert @(SynTree BinOp Char) (Leaf 'A') == Var 'A'

--- a/test/SynTreeSpec.hs
+++ b/test/SynTreeSpec.hs
@@ -17,7 +17,8 @@ import Trees.Helpers (
   treeDepth,
   treeNodes,
   maxNodesForDepth,
-  numOfUniqueBinOpsInSynTree)
+  numOfUniqueBinOpsInSynTree,
+  maxDepthForNodes)
 import SAT.MiniSat hiding (Formula(Not))
 import qualified SAT.MiniSat as Sat (Formula(Not))
 import Trees.Types (SynTree(..), BinOp(..))
@@ -38,7 +39,7 @@ validBoundsSynTree = do
   let minDepth = 1 + floor (logBase (2 :: Double) $ fromIntegral minNodes)
   let minMaxDepth = max (maxConsecutiveNegations + 1) minDepth
   maxDepth <- choose (minMaxDepth,max (minMaxDepth+ 3) 10)
-  maxNodes <- choose (minNodes, maxNodesForDepth maxDepth) `suchThat` \maxNodes' -> maxConsecutiveNegations /= 0 || odd maxNodes'
+  maxNodes <- choose (minNodes, maxNodesForDepth maxDepth) `suchThat` \maxNodes' -> (maxConsecutiveNegations /= 0 || odd maxNodes') && maxDepth <= maxDepthForNodes maxConsecutiveNegations maxNodes'
   let availableBinOpsCount = if allowArrowOperators then fromIntegral $ length [minBound .. maxBound :: BinOp] else 2
   minUniqueBinOperators <- choose (1, min (minDepth - 1) availableBinOpsCount)
   return $ SynTreeConfig {

--- a/test/SynTreeSpec.hs
+++ b/test/SynTreeSpec.hs
@@ -35,7 +35,7 @@ validBoundsSynTree = do
   maxConsecutiveNegations <- choose (0, 3)
   availableAtoms <- sublistOf ['A' .. 'Z'] `suchThat` (not . null)
   minAmountOfUniqueAtoms <- choose (1, fromIntegral $ length availableAtoms)
-  minNodes <- choose (minAmountOfUniqueAtoms * 2, 60) `suchThat` \minNodes' -> maxConsecutiveNegations /= 0 || odd minNodes'
+  minNodes <- choose (max 3 (minAmountOfUniqueAtoms * 2), 60) `suchThat` \minNodes' -> maxConsecutiveNegations /= 0 || odd minNodes'
   let minDepth = 1 + floor (logBase (2 :: Double) $ fromIntegral minNodes)
   let minMaxDepth = max (maxConsecutiveNegations + 1) minDepth
   maxDepth <- choose (minMaxDepth,max (minMaxDepth+ 3) 10)
@@ -43,7 +43,7 @@ validBoundsSynTree = do
     \maxNodes' -> (maxConsecutiveNegations /= 0 || odd maxNodes')
       && maxDepth <= maxDepthForNodes maxConsecutiveNegations maxNodes'
   let availableBinOpsCount = if allowArrowOperators then fromIntegral $ length [minBound .. maxBound :: BinOp] else 2
-  minUniqueBinOperators <- choose (1, min (minDepth - 1) availableBinOpsCount)
+  minUniqueBinOperators <- choose (1, min (minDepth - 1) (min availableBinOpsCount ((minNodes `div` 2) - 1)))
   return $ SynTreeConfig {
     maxNodes,
     minNodes,

--- a/test/SynTreeSpec.hs
+++ b/test/SynTreeSpec.hs
@@ -39,7 +39,9 @@ validBoundsSynTree = do
   let minDepth = 1 + floor (logBase (2 :: Double) $ fromIntegral minNodes)
   let minMaxDepth = max (maxConsecutiveNegations + 1) minDepth
   maxDepth <- choose (minMaxDepth,max (minMaxDepth+ 3) 10)
-  maxNodes <- choose (minNodes, maxNodesForDepth maxDepth) `suchThat` \maxNodes' -> (maxConsecutiveNegations /= 0 || odd maxNodes') && maxDepth <= maxDepthForNodes maxConsecutiveNegations maxNodes'
+  maxNodes <- choose (minNodes, maxNodesForDepth maxDepth) `suchThat`
+    \maxNodes' -> (maxConsecutiveNegations /= 0 || odd maxNodes')
+      && maxDepth <= maxDepthForNodes maxConsecutiveNegations maxNodes'
   let availableBinOpsCount = if allowArrowOperators then fromIntegral $ length [minBound .. maxBound :: BinOp] else 2
   minUniqueBinOperators <- choose (1, min (minDepth - 1) availableBinOpsCount)
   return $ SynTreeConfig {

--- a/test/SynTreeSpec.hs
+++ b/test/SynTreeSpec.hs
@@ -43,7 +43,7 @@ validBoundsSynTree = do
     \maxNodes' -> (maxConsecutiveNegations /= 0 || odd maxNodes')
       && maxDepth <= maxDepthForNodes maxConsecutiveNegations maxNodes'
   let availableBinOpsCount = if allowArrowOperators then fromIntegral $ length [minBound .. maxBound :: BinOp] else 2
-  minUniqueBinOperators <- choose (1, min (minDepth - 1) (min availableBinOpsCount ((minNodes `div` 2) - 1)))
+  minUniqueBinOperators <- choose (1, minimum [maxDepth - 1, availableBinOpsCount, (minNodes - 1) `div` 2])
   return $ SynTreeConfig {
     maxNodes,
     minNodes,


### PR DESCRIPTION
The current implementation of `validBoundsSynTree` can still generate invalid `SynTreeConfig`s. The test cases did not reveal that at my end. I fixed this now. 