### PR TITLE
Fortsetzung `ComposeFormula` & `DecomposeFormula`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 | in Autotool inventory | Direct | Quiz | Autotool module | `logic-tasks` module(s) |
 | :-- | :-: | :-: | :-- | :-- |
 | TODO | | | | [`LogicTasks.Syntax.ComposeFormula`](src/LogicTasks/Syntax/ComposeFormula.hs), [`Tasks.ComposeFormula.Quiz`](src/Tasks/ComposeFormula/Quiz.hs) |
+| TODO | | | | [`LogicTasks.Syntax.DeComposeFormula`](src/LogicTasks/Syntax/DeComposeFormula.hs), [`Tasks.DeComposeFormula.Quiz`](src/Tasks/DeComposeFormula/Quiz.hs) |
 | Aussagenlogik/Syntax/LogicInvalidCnfs | | x | `Logic.Syntax.LegalCnf` | [`LogicTasks.Syntax.IllegalCnfs`](src/LogicTasks/Syntax/IllegalCnfs.hs), [`Tasks.LegalCNF.Quiz`](src/Tasks/LegalCNF/Quiz.hs) |
 | Aussagenlogik/Syntax/LogicInvalidFormulas | | x | `Logic.Syntax.LegalFormula` | [`LogicTasks.Syntax.IllegalFormulas`](src/LogicTasks/Syntax/IllegalFormulas.hs), [`Tasks.LegalProposition.Quiz`](src/Tasks/LegalProposition/Quiz.hs) |
 | Aussagenlogik/Syntax/LogicRemoveBrackets | | x | `Logic.Syntax.SimplestFormula` | [`LogicTasks.Syntax.SimplestFormula`](src/LogicTasks/Syntax/SimplestFormula.hs), [`Tasks.SuperfluousBrackets.Quiz`](src/Tasks/SuperfluousBrackets/Quiz.hs) |

--- a/logic-tasks.cabal
+++ b/logic-tasks.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -32,6 +32,7 @@ library
       LogicTasks.Syntax.SubTreeSet
       LogicTasks.Syntax.TreeToFormula
       LogicTasks.Syntax.ComposeFormula
+      LogicTasks.Syntax.DecomposeFormula
       Tasks.SynTree.Config
       Tasks.SubTree.Config
       Tasks.SubTree.Quiz
@@ -51,6 +52,8 @@ library
       Tasks.LegalCNF.GenerateLegal
       Tasks.ComposeFormula.Config
       Tasks.ComposeFormula.Quiz
+      Tasks.DecomposeFormula.Config
+      Tasks.DecomposeFormula.Quiz
       Trees.Types
       Trees.Parsing
       Trees.Print

--- a/logic-tasks.cabal
+++ b/logic-tasks.cabal
@@ -105,6 +105,7 @@ test-suite src-test
   main-is: Spec.hs
   other-modules:
       ComposeFormulaSpec
+      DecomposeFormulaSpec
       FormulaSpec
       LegalCNFSpec
       LegalPropositionSpec

--- a/logic-tasks.cabal
+++ b/logic-tasks.cabal
@@ -104,6 +104,7 @@ test-suite src-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      ComposeFormulaSpec
       FormulaSpec
       LegalCNFSpec
       LegalPropositionSpec

--- a/package.yaml
+++ b/package.yaml
@@ -48,6 +48,7 @@ library:
     - LogicTasks.Syntax.SubTreeSet
     - LogicTasks.Syntax.TreeToFormula
     - LogicTasks.Syntax.ComposeFormula
+    - LogicTasks.Syntax.DecomposeFormula
     - Tasks.SynTree.Config
     - Tasks.SubTree.Config
     - Tasks.SubTree.Quiz
@@ -67,6 +68,8 @@ library:
     - Tasks.LegalCNF.GenerateLegal
     - Tasks.ComposeFormula.Config
     - Tasks.ComposeFormula.Quiz
+    - Tasks.DecomposeFormula.Config
+    - Tasks.DecomposeFormula.Quiz
     - Trees.Types
     - Trees.Parsing
     - Trees.Print

--- a/src/LogicTasks/Syntax/ComposeFormula.hs
+++ b/src/LogicTasks/Syntax/ComposeFormula.hs
@@ -36,7 +36,7 @@ description path ComposeFormulaInst{..} = do
     instruct $ do
       english $ "Imagine that the two displayed " ++ eTreesOrFormulas ++ " are hung below a root node with operator "
       english $ showOperator operator
-      english $ ". One " ++ eTreeOrFormula ++" on the left and the other " ++ eTreeOrFormula ++" on the right, and once the other way around."
+      english $ ". Once one " ++ eTreeOrFormula ++" on the left and the other " ++ eTreeOrFormula ++" on the right, and once the other way around."
       german $ "Stellen Sie sich vor, die beiden angezeigten " ++ gTreesOrFormulas ++" würden unterhalb eines Wurzelknotens mit Operator "
       german $ showOperator operator
       german $ " gehängt. Einmal " ++ derDie ++" eine " ++ gTreeOrFormula ++" links und " ++ derDie ++" andere " ++ gTreeOrFormula ++" rechts, und einmal genau andersherum."
@@ -60,8 +60,8 @@ description path ComposeFormulaInst{..} = do
       german "(In den Formeln dürfen Sie beliebig viele zusätzliche Klammerpaare hinzufügen.)"
 
     when addExtraHintsOnAssociativity $ instruct $ do
-        english "Remark: Do not try to use associativity in this task in order to save brackets."
-        german "Hinweis: Sie dürfen bei dieser Aufgabe nicht Klammern durch Verwendung von Assoziativität einsparen."
+        english "Remark: Do not try to use associativity in order to omit brackets in this task."
+        german "Hinweis: Sie dürfen bei dieser Aufgabe nicht Klammern durch Verwendung von Assoziativität weglassen."
 
     keyHeading
     basicOpKey

--- a/src/LogicTasks/Syntax/DecomposeFormula.hs
+++ b/src/LogicTasks/Syntax/DecomposeFormula.hs
@@ -1,0 +1,143 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module LogicTasks.Syntax.DecomposeFormula where
+
+
+import Control.Monad.Output (
+  LangM,
+  OutputMonad, german, english,
+  GenericOutputMonad (paragraph, indent, translatedCode, refuse, image), translate, localise, translations, ($=<<)
+  )
+
+import LogicTasks.Helpers (extra, example, instruct, keyHeading, basicOpKey, reject)
+import Trees.Types (TreeFormulaAnswer(..))
+import Tasks.DecomposeFormula.Config (DecomposeFormulaInst(..), DecomposeFormulaConfig, checkDecomposeFormulaConfig)
+import Trees.Print (display, transferToPicture)
+import Control.Monad (when, unless)
+import Data.Maybe (isNothing, fromJust)
+import Trees.Helpers (collectLeaves, collectUniqueBinOpsInSynTree, swapKids)
+import Data.Containers.ListUtils (nubOrd)
+import Control.Monad.Cont (MonadIO (liftIO))
+import LogicTasks.Syntax.TreeToFormula (cacheTree)
+
+
+
+
+description :: OutputMonad m => DecomposeFormulaInst -> LangM m
+description DecomposeFormulaInst{..} = do
+
+    example (display tree) $ do
+      english "The following formula is given:"
+      german "Die folgende Formel ist gegeben:"
+
+    instruct $ do
+      english "Create the syntax tree for this formula and swap the two subtrees at the root. "
+      english "Finally, enter the formula for the resulting syntax tree."
+      german "Erstellen Sie den Syntaxbaum zu dieser Formel und tauschen Sie die beiden Teilbäume an der Wurzel. "
+      german "Geben Sie anschließend die Formel für den entstandenen Syntaxbaum ein."
+
+    instruct $ do
+      english "(You are allowed to add arbitrarily many additional pairs of brackets in the formula.)"
+      german "(In der Formel dürfen Sie beliebig viele zusätzliche Klammerpaare hinzufügen.)"
+
+    when addExtraHintsOnAssociativity $ instruct $ do
+      english "Remark: Do not try to use associativity in this task in order to save brackets."
+      german "Hinweis: Sie dürfen bei dieser Aufgabe nicht Klammern durch Verwendung von Assoziativität einsparen."
+
+    keyHeading
+    basicOpKey
+
+    paragraph $ indent $ do
+      translate $ do
+        english "A solution attempt could look like this: "
+        german "Ein Lösungsversuch könnte beispielsweise so aussehen: "
+      translatedCode $ flip localise $ translations $ do
+        english "(A or not B) and C"
+        german "(A oder nicht B) und C"
+      pure ()
+
+    extra addText
+    pure ()
+
+
+verifyInst :: OutputMonad m => DecomposeFormulaInst -> LangM m
+verifyInst _ = pure ()
+
+
+
+verifyConfig :: OutputMonad m => DecomposeFormulaConfig -> LangM m
+verifyConfig = checkDecomposeFormulaConfig
+
+
+
+start :: TreeFormulaAnswer
+start = TreeFormulaAnswer Nothing
+
+
+
+partialGrade :: OutputMonad m => DecomposeFormulaInst -> TreeFormulaAnswer -> LangM m
+partialGrade DecomposeFormulaInst{..} sol = do
+
+  when (isNothing solTree) $ reject $ do
+    english "You did not submit a solution."
+    german "Die Abgabe ist leer."
+
+  when (any (`notElem` origLiterals) solLiterals) $ reject $ do
+    english "Your solution contains unknown literals."
+    german "Ihre Abgabe beinhaltet unbekannte Literale."
+
+  unless (length origLiterals == length solLiterals) $ reject $ do
+    english "Your solution does not contain all literals present in the original formula."
+    german "Ihre Abgabe beinhaltet nicht alle Literale aus der ursprünglichen Formel."
+
+  unless (length origOperators == length solOperators) $ reject $ do
+    english "Your solution contains too many different operators."
+    german "Ihre Abgabe beinhaltet zu viele unterschiedliche Operatoren."
+
+  pure ()
+    where solTree = maybeTree sol
+          origLiterals = nubOrd $ collectLeaves tree
+          solLiterals = nubOrd $ collectLeaves $ fromJust solTree
+          origOperators = collectUniqueBinOpsInSynTree tree
+          solOperators = collectUniqueBinOpsInSynTree $ fromJust solTree
+
+
+
+
+completeGrade :: (OutputMonad m, MonadIO m) => FilePath -> DecomposeFormulaInst -> TreeFormulaAnswer -> LangM m
+completeGrade path DecomposeFormulaInst{..} sol
+  | solTree /= swapKids tree = refuse $ do
+    instruct $ do
+      english "Your solution is not correct."
+      german "Ihre Abgabe ist nicht die korrekte Lösung."
+
+    instruct $ do
+      english "The original syntax tree looks like this:"
+      german "Der originale Syntaxbaum sieht so aus:"
+
+    image $=<< liftIO $ cacheTree (transferToPicture tree) path
+
+    instruct $ do
+      english "The syntax tree for your entered formula looks like this:"
+      german "Der Syntaxbaum für Ihre eingegebene Formel sieht so aus:"
+
+    image $=<< liftIO $ cacheTree (transferToPicture solTree) path
+
+    when showSolution $ do
+      example (show (swapKids tree)) $ do
+        english "The solution for this task is:"
+        german "Die Lösung für die Aufgabe ist:"
+
+      instruct $ do
+        english "The corresponding syntax tree looks like this:"
+        german "Der zugehörige Syntaxbaum sieht so aus:"
+
+      image $=<< liftIO $ cacheTree (transferToPicture (swapKids tree)) path
+
+      pure ()
+
+    pure ()
+  | otherwise = pure ()
+    where solTree = fromJust $ maybeTree sol

--- a/src/LogicTasks/Syntax/DecomposeFormula.hs
+++ b/src/LogicTasks/Syntax/DecomposeFormula.hs
@@ -45,8 +45,8 @@ description DecomposeFormulaInst{..} = do
       german "(In der Formel dürfen Sie beliebig viele zusätzliche Klammerpaare hinzufügen.)"
 
     when addExtraHintsOnAssociativity $ instruct $ do
-      english "Remark: Do not try to use associativity in this task in order to save brackets."
-      german "Hinweis: Sie dürfen bei dieser Aufgabe nicht Klammern durch Verwendung von Assoziativität einsparen."
+        english "Remark: Do not try to use associativity in order to omit brackets in this task."
+        german "Hinweis: Sie dürfen bei dieser Aufgabe nicht Klammern durch Verwendung von Assoziativität weglassen."
 
     keyHeading
     basicOpKey

--- a/src/LogicTasks/Syntax/DecomposeFormula.hs
+++ b/src/LogicTasks/Syntax/DecomposeFormula.hs
@@ -21,6 +21,8 @@ import Trees.Helpers (collectLeaves, collectUniqueBinOpsInSynTree, swapKids)
 import Data.Containers.ListUtils (nubOrd)
 import Control.Monad.Cont (MonadIO (liftIO))
 import LogicTasks.Syntax.TreeToFormula (cacheTree)
+import Formula.Parsing (Parse(parser))
+import Formula.Parsing.Delayed (Delayed, withDelayed)
 
 
 
@@ -77,9 +79,11 @@ start :: TreeFormulaAnswer
 start = TreeFormulaAnswer Nothing
 
 
+partialGrade :: OutputMonad m => DecomposeFormulaInst -> Delayed TreeFormulaAnswer -> LangM m
+partialGrade inst = partialGrade' inst `withDelayed` parser
 
-partialGrade :: OutputMonad m => DecomposeFormulaInst -> TreeFormulaAnswer -> LangM m
-partialGrade DecomposeFormulaInst{..} sol = do
+partialGrade' :: OutputMonad m => DecomposeFormulaInst -> TreeFormulaAnswer -> LangM m
+partialGrade' DecomposeFormulaInst{..} sol = do
 
   when (isNothing solTree) $ reject $ do
     english "You did not submit a solution."
@@ -106,9 +110,11 @@ partialGrade DecomposeFormulaInst{..} sol = do
 
 
 
+completeGrade :: (OutputMonad m, MonadIO m) => FilePath -> DecomposeFormulaInst -> Delayed TreeFormulaAnswer -> LangM m
+completeGrade path inst = completeGrade' path inst `withDelayed` parser
 
-completeGrade :: (OutputMonad m, MonadIO m) => FilePath -> DecomposeFormulaInst -> TreeFormulaAnswer -> LangM m
-completeGrade path DecomposeFormulaInst{..} sol
+completeGrade' :: (OutputMonad m, MonadIO m) => FilePath -> DecomposeFormulaInst -> TreeFormulaAnswer -> LangM m
+completeGrade' path DecomposeFormulaInst{..} sol
   | solTree /= swappedTree = refuse $ do
     instruct $ do
       english "Your solution is not correct."

--- a/src/LogicTasks/Syntax/DecomposeFormula.hs
+++ b/src/LogicTasks/Syntax/DecomposeFormula.hs
@@ -11,7 +11,7 @@ import Control.Monad.Output (
   GenericOutputMonad (paragraph, indent, translatedCode, refuse, image), translate, localise, translations, ($=<<)
   )
 
-import LogicTasks.Helpers (extra, example, instruct, keyHeading, basicOpKey, reject)
+import LogicTasks.Helpers (extra, example, instruct, keyHeading, basicOpKey, arrowsKey, reject)
 import Trees.Types (TreeFormulaAnswer(..))
 import Tasks.DecomposeFormula.Config (DecomposeFormulaInst(..), DecomposeFormulaConfig, checkDecomposeFormulaConfig)
 import Trees.Print (display, transferToPicture)
@@ -48,6 +48,7 @@ description DecomposeFormulaInst{..} = do
 
     keyHeading
     basicOpKey
+    arrowsKey
 
     paragraph $ indent $ do
       translate $ do
@@ -93,8 +94,8 @@ partialGrade DecomposeFormulaInst{..} sol = do
     german "Ihre Abgabe beinhaltet nicht alle Literale aus der ursprünglichen Formel."
 
   unless (length origOperators == length solOperators) $ reject $ do
-    english "Your solution contains too many different operators."
-    german "Ihre Abgabe beinhaltet zu viele unterschiedliche Operatoren."
+    english "Your solution does not contain the right amount of different operators."
+    german "Ihre Abgabe beinhaltet nicht die richtige Anzahl an unterschiedlichen Operatoren."
 
   pure ()
     where solTree = maybeTree sol
@@ -108,7 +109,7 @@ partialGrade DecomposeFormulaInst{..} sol = do
 
 completeGrade :: (OutputMonad m, MonadIO m) => FilePath -> DecomposeFormulaInst -> TreeFormulaAnswer -> LangM m
 completeGrade path DecomposeFormulaInst{..} sol
-  | solTree /= swapKids tree = refuse $ do
+  | solTree /= swappedTree = refuse $ do
     instruct $ do
       english "Your solution is not correct."
       german "Ihre Abgabe ist nicht die korrekte Lösung."
@@ -126,7 +127,7 @@ completeGrade path DecomposeFormulaInst{..} sol
     image $=<< liftIO $ cacheTree (transferToPicture solTree) path
 
     when showSolution $ do
-      example (show (swapKids tree)) $ do
+      example (show swappedTree) $ do
         english "The solution for this task is:"
         german "Die Lösung für die Aufgabe ist:"
 
@@ -134,10 +135,12 @@ completeGrade path DecomposeFormulaInst{..} sol
         english "The corresponding syntax tree looks like this:"
         german "Der zugehörige Syntaxbaum sieht so aus:"
 
-      image $=<< liftIO $ cacheTree (transferToPicture (swapKids tree)) path
+      image $=<< liftIO $ cacheTree (transferToPicture swappedTree) path
 
       pure ()
 
     pure ()
   | otherwise = pure ()
     where solTree = fromJust $ maybeTree sol
+          swappedTree = swapKids tree
+

--- a/src/Tasks/ComposeFormula/Config.hs
+++ b/src/Tasks/ComposeFormula/Config.hs
@@ -18,7 +18,7 @@ import GHC.Generics
 import Control.Monad.Output (Language, OutputMonad, LangM, english, german)
 import LogicTasks.Helpers (reject)
 
-data TreeDisplayMode = FormulaDisplay | TreeDisplay deriving (Show,Eq)
+data TreeDisplayMode = FormulaDisplay | TreeDisplay deriving (Show,Eq, Enum, Bounded)
 
 data ComposeFormulaConfig = ComposeFormulaConfig {
       syntaxTreeConfig :: SynTreeConfig
@@ -27,7 +27,7 @@ data ComposeFormulaConfig = ComposeFormulaConfig {
     , extraText :: Maybe (Map Language String)
     , printSolution :: Bool
     }
-    deriving (Typeable, Generic)
+    deriving (Typeable, Generic, Show)
 
 defaultComposeFormulaConfig :: ComposeFormulaConfig
 defaultComposeFormulaConfig = ComposeFormulaConfig

--- a/src/Tasks/ComposeFormula/Config.hs
+++ b/src/Tasks/ComposeFormula/Config.hs
@@ -49,6 +49,9 @@ checkAdditionalConfig ComposeFormulaConfig {syntaxTreeConfig=SynTreeConfig {..}}
     | minUniqueBinOperators < 1 = reject $ do
         english "There should be a positive number of (unique) operators."
         german "Es sollte eine positive Anzahl an (unterschiedlichen) Operatoren geben."
+    | minNodes < 7 = reject $ do
+        english "Minimum number of nodes restricts the number of possible subtrees too much."
+        german "Minimale Anzahl an Knoten schränkt die Anzahl der möglichen Teilbäume zu stark ein."
     | otherwise = pure ()
 
 

--- a/src/Tasks/ComposeFormula/Config.hs
+++ b/src/Tasks/ComposeFormula/Config.hs
@@ -49,9 +49,6 @@ checkAdditionalConfig ComposeFormulaConfig {syntaxTreeConfig=SynTreeConfig {..}}
     | minUniqueBinOperators < 1 = reject $ do
         english "There should be a positive number of (unique) operators."
         german "Es sollte eine positive Anzahl an (unterschiedlichen) Operatoren geben."
-    | minNodes < 2 * minUniqueBinOperators + 3 = reject $ do
-        english "Minimal number of nodes must larger, given the desired number of unique operators."
-        german "Minimale Anzahl Knoten muss größer sein, angesichts der angestrebten Anzahl unterschiedlicher Operatoren."
     | otherwise = pure ()
 
 

--- a/src/Tasks/ComposeFormula/Quiz.hs
+++ b/src/Tasks/ComposeFormula/Quiz.hs
@@ -9,10 +9,11 @@ import Trees.Generate (genSynTree)
 import Test.QuickCheck (Gen, suchThat,)
 
 import Tasks.ComposeFormula.Config (ComposeFormulaConfig(..), ComposeFormulaInst(..), TreeDisplayMode (FormulaDisplay))
-import Trees.Helpers (binOp, bothKids)
+import Trees.Helpers (binOp, bothKids, mirrorTree)
 import Data.Maybe (fromJust)
 import Trees.Print (transferToPicture)
 import Trees.Types (BinOp(Equi, Or, And))
+import Data.List.Extra (nubOrd)
 
 
 
@@ -20,7 +21,8 @@ import Trees.Types (BinOp(Equi, Or, And))
 generateComposeFormulaInst :: ComposeFormulaConfig -> Gen ComposeFormulaInst
 generateComposeFormulaInst ComposeFormulaConfig {..} = do
     tree <- genSynTree syntaxTreeConfig `suchThat` \synTree ->
-      binOp synTree `elem` map Just [And, Or, Equi] && let (lk, rk) = bothKids synTree in lk /= rk
+      binOp synTree `elem` map Just [And, Or, Equi] && let (lk, rk) = bothKids synTree in
+        length (nubOrd [lk, rk, mirrorTree lk, mirrorTree rk]) == 4
     let (leftTree, rightTree) = bothKids tree
     return $ ComposeFormulaInst
       { operator = fromJust $ binOp tree

--- a/src/Tasks/ComposeFormula/Quiz.hs
+++ b/src/Tasks/ComposeFormula/Quiz.hs
@@ -19,8 +19,8 @@ import Trees.Types (BinOp(Equi, Or, And))
 
 generateComposeFormulaInst :: ComposeFormulaConfig -> Gen ComposeFormulaInst
 generateComposeFormulaInst ComposeFormulaConfig {..} = do
-    tree <- genSynTree syntaxTreeConfig
-          `suchThat` \synTree -> binOp synTree `elem` map Just [And, Or, Equi]
+    tree <- genSynTree syntaxTreeConfig `suchThat` \synTree ->
+      binOp synTree `elem` map Just [And, Or, Equi] && let (lk, rk) = bothKids synTree in lk /= rk
     let (leftTree, rightTree) = bothKids tree
     return $ ComposeFormulaInst
       { operator = fromJust $ binOp tree

--- a/src/Tasks/DecomposeFormula/Config.hs
+++ b/src/Tasks/DecomposeFormula/Config.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+module Tasks.DecomposeFormula.Config (
+    DecomposeFormulaConfig (..),
+    DecomposeFormulaInst (..),
+    defaultDecomposeFormulaConfig,
+    checkDecomposeFormulaConfig
+    ) where
+
+import Tasks.SynTree.Config (SynTreeConfig(..), defaultSynTreeConfig, checkSynTreeConfig)
+import Data.Map (Map)
+import Trees.Types (SynTree(..), BinOp(..))
+import Data.Typeable
+import GHC.Generics
+import Control.Monad.Output (Language, OutputMonad, LangM)
+
+data DecomposeFormulaConfig = DecomposeFormulaConfig {
+      syntaxTreeConfig :: SynTreeConfig
+    , extraHintsOnAssociativity :: Bool
+    , extraText :: Maybe (Map Language String)
+    , printSolution :: Bool
+    }
+    deriving (Typeable, Generic)
+
+defaultDecomposeFormulaConfig :: DecomposeFormulaConfig
+defaultDecomposeFormulaConfig = DecomposeFormulaConfig
+    { syntaxTreeConfig = defaultSynTreeConfig
+    , extraHintsOnAssociativity = True
+    , extraText = Nothing
+    , printSolution = True
+    }
+
+
+
+checkDecomposeFormulaConfig :: OutputMonad m => DecomposeFormulaConfig -> LangM m
+checkDecomposeFormulaConfig DecomposeFormulaConfig {..} =
+    checkSynTreeConfig syntaxTreeConfig
+
+
+data DecomposeFormulaInst = DecomposeFormulaInst
+               { tree :: SynTree BinOp Char
+               , addExtraHintsOnAssociativity :: Bool
+               , addText :: Maybe (Map Language String)
+               , showSolution :: Bool
+               }
+               deriving (Show, Typeable, Generic)
+

--- a/src/Tasks/DecomposeFormula/Config.hs
+++ b/src/Tasks/DecomposeFormula/Config.hs
@@ -23,7 +23,7 @@ data DecomposeFormulaConfig = DecomposeFormulaConfig {
     , extraText :: Maybe (Map Language String)
     , printSolution :: Bool
     }
-    deriving (Typeable, Generic)
+    deriving (Typeable, Generic, Show)
 
 defaultDecomposeFormulaConfig :: DecomposeFormulaConfig
 defaultDecomposeFormulaConfig = DecomposeFormulaConfig

--- a/src/Tasks/DecomposeFormula/Config.hs
+++ b/src/Tasks/DecomposeFormula/Config.hs
@@ -44,9 +44,6 @@ checkAdditionalConfig DecomposeFormulaConfig {syntaxTreeConfig=SynTreeConfig {..
     | minUniqueBinOperators < 1 = reject $ do
         english "There should be a positive number of (unique) operators."
         german "Es sollte eine positive Anzahl an (unterschiedlichen) Operatoren geben."
-    | minNodes < 2 * minUniqueBinOperators + 3 = reject $ do
-        english "Minimal number of nodes must larger, given the desired number of unique operators."
-        german "Minimale Anzahl Knoten muss größer sein, angesichts der angestrebten Anzahl unterschiedlicher Operatoren."
     | otherwise = pure ()
 
 data DecomposeFormulaInst = DecomposeFormulaInst

--- a/src/Tasks/DecomposeFormula/Config.hs
+++ b/src/Tasks/DecomposeFormula/Config.hs
@@ -44,6 +44,9 @@ checkAdditionalConfig DecomposeFormulaConfig {syntaxTreeConfig=SynTreeConfig {..
     | minUniqueBinOperators < 1 = reject $ do
         english "There should be a positive number of (unique) operators."
         german "Es sollte eine positive Anzahl an (unterschiedlichen) Operatoren geben."
+    | minNodes < 7 = reject $ do
+        english "Minimum number of nodes restricts the number of possible subtrees too much."
+        german "Minimale Anzahl an Knoten schränkt die Anzahl der möglichen Teilbäume zu stark ein."
     | otherwise = pure ()
 
 data DecomposeFormulaInst = DecomposeFormulaInst

--- a/src/Tasks/DecomposeFormula/Quiz.hs
+++ b/src/Tasks/DecomposeFormula/Quiz.hs
@@ -10,7 +10,7 @@ import Trees.Generate (genSynTree)
 import Test.QuickCheck (Gen, suchThat,)
 
 import Tasks.DecomposeFormula.Config (DecomposeFormulaConfig(..), DecomposeFormulaInst(..))
-import Trees.Helpers (binOp)
+import Trees.Helpers (binOp, bothKids)
 import Trees.Types (BinOp(Equi, Or, And))
 
 
@@ -18,8 +18,8 @@ import Trees.Types (BinOp(Equi, Or, And))
 
 generateDecomposeFormulaInst :: DecomposeFormulaConfig -> Gen DecomposeFormulaInst
 generateDecomposeFormulaInst DecomposeFormulaConfig {..} = do
-    tree <- genSynTree syntaxTreeConfig
-          `suchThat` \synTree -> binOp synTree `elem` map Just [And, Or, Equi]
+    tree <- genSynTree syntaxTreeConfig `suchThat` \synTree ->
+      binOp synTree `elem` map Just [And, Or, Equi] && let (lk, rk) = bothKids synTree in lk /= rk
     return $ DecomposeFormulaInst
       { tree
       , addExtraHintsOnAssociativity = extraHintsOnAssociativity

--- a/src/Tasks/DecomposeFormula/Quiz.hs
+++ b/src/Tasks/DecomposeFormula/Quiz.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Tasks.DecomposeFormula.Quiz(
+    generateDecomposeFormulaInst,
+    ) where
+
+
+import Trees.Generate (genSynTree)
+import Test.QuickCheck (Gen, suchThat,)
+
+import Tasks.DecomposeFormula.Config (DecomposeFormulaConfig(..), DecomposeFormulaInst(..))
+import Trees.Helpers (binOp)
+import Trees.Types (BinOp(Equi, Or, And))
+
+
+
+
+generateDecomposeFormulaInst :: DecomposeFormulaConfig -> Gen DecomposeFormulaInst
+generateDecomposeFormulaInst DecomposeFormulaConfig {..} = do
+    tree <- genSynTree syntaxTreeConfig
+          `suchThat` \synTree -> binOp synTree `elem` map Just [And, Or, Equi]
+    return $ DecomposeFormulaInst
+      { tree
+      , addExtraHintsOnAssociativity = extraHintsOnAssociativity
+      , addText = extraText
+      , showSolution = printSolution
+      }

--- a/src/Tasks/DecomposeFormula/Quiz.hs
+++ b/src/Tasks/DecomposeFormula/Quiz.hs
@@ -12,7 +12,7 @@ import Test.QuickCheck (Gen, suchThat,)
 import Tasks.DecomposeFormula.Config (DecomposeFormulaConfig(..), DecomposeFormulaInst(..))
 import Trees.Helpers (binOp, bothKids, mirrorTree)
 import Trees.Types (BinOp(Equi, Or, And))
-import Data.Containers.ListUtils (nubOrd)
+import Data.List.Extra (nubOrd)
 
 
 

--- a/src/Tasks/DecomposeFormula/Quiz.hs
+++ b/src/Tasks/DecomposeFormula/Quiz.hs
@@ -10,8 +10,9 @@ import Trees.Generate (genSynTree)
 import Test.QuickCheck (Gen, suchThat,)
 
 import Tasks.DecomposeFormula.Config (DecomposeFormulaConfig(..), DecomposeFormulaInst(..))
-import Trees.Helpers (binOp, bothKids)
+import Trees.Helpers (binOp, bothKids, mirrorTree)
 import Trees.Types (BinOp(Equi, Or, And))
+import Data.Containers.ListUtils (nubOrd)
 
 
 
@@ -19,7 +20,8 @@ import Trees.Types (BinOp(Equi, Or, And))
 generateDecomposeFormulaInst :: DecomposeFormulaConfig -> Gen DecomposeFormulaInst
 generateDecomposeFormulaInst DecomposeFormulaConfig {..} = do
     tree <- genSynTree syntaxTreeConfig `suchThat` \synTree ->
-      binOp synTree `elem` map Just [And, Or, Equi] && let (lk, rk) = bothKids synTree in lk /= rk
+      binOp synTree `elem` map Just [And, Or, Equi] && let (lk, rk) = bothKids synTree in
+        length (nubOrd [lk, rk, mirrorTree lk, mirrorTree rk]) == 4
     return $ DecomposeFormulaInst
       { tree
       , addExtraHintsOnAssociativity = extraHintsOnAssociativity

--- a/src/Trees/Helpers.hs
+++ b/src/Trees/Helpers.hs
@@ -178,8 +178,8 @@ collectUniqueBinOpsInSynTree (Binary op l r) = nubOrd $ concat [
   collectUniqueBinOpsInSynTree r]
 
 mirrorTree :: SynTree BinOp c -> SynTree BinOp c
-mirrorTree (Binary Impl l r) = Binary BackImpl r l
-mirrorTree (Binary BackImpl l r) = Binary Impl r l
-mirrorTree (Binary b l r) = Binary b r l
+mirrorTree (Binary Impl l r) = Binary BackImpl (mirrorTree r) (mirrorTree l)
+mirrorTree (Binary BackImpl l r) = Binary Impl (mirrorTree r) (mirrorTree l)
+mirrorTree (Binary b l r) = Binary b (mirrorTree r) (mirrorTree l)
 mirrorTree (Not x) = Not $ mirrorTree x
 mirrorTree x = x

--- a/src/Trees/Helpers.hs
+++ b/src/Trees/Helpers.hs
@@ -154,7 +154,7 @@ numOfOpsInFormula (Neg f) = numOfOpsInFormula f
 numOfOpsInFormula (Brackets f) = numOfOpsInFormula f
 numOfOpsInFormula (Assoc _ f1 f2) = 1 + numOfOpsInFormula f1 + numOfOpsInFormula f2
 
-numOfUniqueBinOpsInSynTree :: SynTree BinOp c -> Integer
+numOfUniqueBinOpsInSynTree :: (Eq o, Ord o) => SynTree o c -> Integer
 numOfUniqueBinOpsInSynTree = fromIntegral . length . collectUniqueBinOpsInSynTree
 
 binOp :: SynTree BinOp a -> Maybe BinOp
@@ -169,7 +169,7 @@ swapKids :: SynTree o a -> SynTree o a
 swapKids (Binary x l r) = Binary x r l
 swapKids _ = error "impossible to land here"
 
-collectUniqueBinOpsInSynTree :: SynTree BinOp a -> [BinOp]
+collectUniqueBinOpsInSynTree :: (Eq o, Ord o) => SynTree o a -> [o]
 collectUniqueBinOpsInSynTree (Leaf _) = []
 collectUniqueBinOpsInSynTree (Not x) = collectUniqueBinOpsInSynTree x
 collectUniqueBinOpsInSynTree (Binary op l r) = nubOrd $ concat [

--- a/src/Trees/Helpers.hs
+++ b/src/Trees/Helpers.hs
@@ -26,6 +26,7 @@ module Trees.Helpers
     bothKids,
     swapKids,
     collectUniqueBinOpsInSynTree,
+    mirrorTree
     ) where
 
 import Control.Monad (void)
@@ -175,3 +176,8 @@ collectUniqueBinOpsInSynTree (Binary op l r) = nubOrd $ concat [
   [op],
   collectUniqueBinOpsInSynTree l,
   collectUniqueBinOpsInSynTree r]
+
+mirrorTree :: SynTree o c -> SynTree o c
+mirrorTree (Binary b l r) = Binary b r l
+mirrorTree (Not x) = Not $ mirrorTree x
+mirrorTree x = x

--- a/src/Trees/Helpers.hs
+++ b/src/Trees/Helpers.hs
@@ -177,7 +177,9 @@ collectUniqueBinOpsInSynTree (Binary op l r) = nubOrd $ concat [
   collectUniqueBinOpsInSynTree l,
   collectUniqueBinOpsInSynTree r]
 
-mirrorTree :: SynTree o c -> SynTree o c
+mirrorTree :: SynTree BinOp c -> SynTree BinOp c
+mirrorTree (Binary Impl l r) = Binary BackImpl r l
+mirrorTree (Binary BackImpl l r) = Binary Impl r l
 mirrorTree (Binary b l r) = Binary b r l
 mirrorTree (Not x) = Not $ mirrorTree x
 mirrorTree x = x

--- a/src/Trees/Helpers.hs
+++ b/src/Trees/Helpers.hs
@@ -23,7 +23,8 @@ module Trees.Helpers
     numOfUniqueBinOpsInSynTree,
     binOp,
     bothKids,
-    collectUniqueBinOpsInSynTree
+    swapKids,
+    collectUniqueBinOpsInSynTree,
     ) where
 
 import Control.Monad (void)
@@ -154,6 +155,10 @@ binOp _ = Nothing
 bothKids :: SynTree o a -> (SynTree o a, SynTree o a)
 bothKids (Binary _ l r) = (l, r)
 bothKids _ = error "impossible to land here"
+
+swapKids :: SynTree o a -> SynTree o a
+swapKids (Binary x l r) = Binary x r l
+swapKids _ = error "impossible to land here"
 
 collectUniqueBinOpsInSynTree :: SynTree BinOp a -> [BinOp]
 collectUniqueBinOpsInSynTree (Leaf _) = []

--- a/test/ComposeFormulaSpec.hs
+++ b/test/ComposeFormulaSpec.hs
@@ -21,7 +21,7 @@ import Tasks.ComposeFormula.Quiz (generateComposeFormulaInst)
 validBoundsComposeFormula :: Gen ComposeFormulaConfig
 validBoundsComposeFormula = do
   syntaxTreeConfig <- validBoundsSynTree `suchThat` \SynTreeConfig{..} ->
-    minUniqueBinOperators >= 1 && minNodes >= 2 * minUniqueBinOperators + 3
+    minUniqueBinOperators >= 1
   displayModeL <- elements [minBound..maxBound :: TreeDisplayMode]
   displayModeR <- elements [minBound..maxBound :: TreeDisplayMode]
   return ComposeFormulaConfig {

--- a/test/ComposeFormulaSpec.hs
+++ b/test/ComposeFormulaSpec.hs
@@ -18,7 +18,7 @@ import Control.Monad.Identity (Identity(runIdentity))
 import Control.Monad.Output.Generic (evalLangM)
 import Tasks.ComposeFormula.Quiz (generateComposeFormulaInst)
 import Trees.Types (SynTree(Binary), TreeFormulaAnswer (TreeFormulaAnswer))
-import LogicTasks.Syntax.ComposeFormula (partialGrade)
+import LogicTasks.Syntax.ComposeFormula (partialGrade')
 
 validBoundsComposeFormula :: Gen ComposeFormulaConfig
 validBoundsComposeFormula = do
@@ -49,7 +49,7 @@ spec = do
           let lrTree = Binary operator leftTree rightTree
               rlTree = Binary operator rightTree leftTree
           in isJust $ runIdentity $ evalLangM
-            (partialGrade inst [TreeFormulaAnswer (Just lrTree), TreeFormulaAnswer (Just rlTree)] :: LangM Maybe)
+            (partialGrade' inst [TreeFormulaAnswer (Just lrTree), TreeFormulaAnswer (Just rlTree)] :: LangM Maybe)
     it "leftTreeImage and rightTreeImage has the right value" $
       forAll validBoundsComposeFormula $ \composeFormulaConfig@ComposeFormulaConfig{..} ->
         forAll (generateComposeFormulaInst composeFormulaConfig) $ \ComposeFormulaInst{..} ->

--- a/test/ComposeFormulaSpec.hs
+++ b/test/ComposeFormulaSpec.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
+module ComposeFormulaSpec where
+
+import Test.Hspec
+import Tasks.ComposeFormula.Config (ComposeFormulaConfig(..), TreeDisplayMode (FormulaDisplay), checkComposeFormulaConfig, defaultComposeFormulaConfig, ComposeFormulaInst(..))
+import Test.QuickCheck
+import SynTreeSpec (validBoundsSynTree)
+import Tasks.SynTree.Config (SynTreeConfig(..))
+import Control.Monad.Output (LangM)
+import Data.Maybe (isJust)
+import Control.Monad.Identity (Identity(runIdentity))
+import Control.Monad.Output.Generic (evalLangM)
+import Tasks.ComposeFormula.Quiz (generateComposeFormulaInst)
+
+validBoundsComposeFormula :: Gen ComposeFormulaConfig
+validBoundsComposeFormula = do
+  syntaxTreeConfig <- validBoundsSynTree `suchThat` \SynTreeConfig{..} ->
+    minUniqueBinOperators >= 1 && minNodes >= 2 * minUniqueBinOperators + 3
+  displayModeL <- elements [minBound..maxBound :: TreeDisplayMode]
+  displayModeR <- elements [minBound..maxBound :: TreeDisplayMode]
+  return ComposeFormulaConfig {
+    syntaxTreeConfig,
+    treeDisplayModes = (displayModeL, displayModeR),
+    extraHintsOnAssociativity = False,
+    extraText = Nothing,
+    printSolution = False
+  }
+
+spec :: Spec
+spec = do
+  describe "config" $ do
+    it "default config should pass config check" $
+      isJust $ runIdentity $ evalLangM (checkComposeFormulaConfig defaultComposeFormulaConfig :: LangM Maybe)
+    it "validBoundsComposeFormula should generate a valid config" $
+      forAll validBoundsComposeFormula $ \composeFormulaConfig ->
+        isJust $ runIdentity $ evalLangM (checkComposeFormulaConfig composeFormulaConfig :: LangM Maybe)
+  describe "generateComposeFormulaInst" $ do
+    it "should generate an instance with different subtrees" $
+      forAll validBoundsComposeFormula $ \composeFormulaConfig ->
+        forAll (generateComposeFormulaInst composeFormulaConfig) $ \ComposeFormulaInst{..} ->
+          leftTree /= rightTree
+    it "leftTreeImage and rightTreeImage has the right value" $
+      forAll validBoundsComposeFormula $ \composeFormulaConfig@ComposeFormulaConfig{..} ->
+        forAll (generateComposeFormulaInst composeFormulaConfig) $ \ComposeFormulaInst{..} ->
+          fst treeDisplayModes == FormulaDisplay || isJust leftTreeImage &&
+          snd treeDisplayModes == FormulaDisplay || isJust rightTreeImage

--- a/test/ComposeFormulaSpec.hs
+++ b/test/ComposeFormulaSpec.hs
@@ -3,7 +3,12 @@
 module ComposeFormulaSpec where
 
 import Test.Hspec
-import Tasks.ComposeFormula.Config (ComposeFormulaConfig(..), TreeDisplayMode (FormulaDisplay), checkComposeFormulaConfig, defaultComposeFormulaConfig, ComposeFormulaInst(..))
+import Tasks.ComposeFormula.Config (
+  ComposeFormulaConfig(..),
+  TreeDisplayMode (FormulaDisplay),
+  checkComposeFormulaConfig,
+  defaultComposeFormulaConfig,
+  ComposeFormulaInst(..))
 import Test.QuickCheck
 import SynTreeSpec (validBoundsSynTree)
 import Tasks.SynTree.Config (SynTreeConfig(..))

--- a/test/DecomposeFormulaSpec.hs
+++ b/test/DecomposeFormulaSpec.hs
@@ -3,7 +3,11 @@
 module DecomposeFormulaSpec where
 
 import Test.Hspec
-import Tasks.DecomposeFormula.Config (DecomposeFormulaConfig(..), checkDecomposeFormulaConfig, defaultDecomposeFormulaConfig, DecomposeFormulaInst(..))
+import Tasks.DecomposeFormula.Config (
+  DecomposeFormulaConfig(..),
+  checkDecomposeFormulaConfig,
+  defaultDecomposeFormulaConfig,
+  DecomposeFormulaInst(..))
 import Test.QuickCheck
 import SynTreeSpec (validBoundsSynTree)
 import Tasks.SynTree.Config (SynTreeConfig(..))

--- a/test/DecomposeFormulaSpec.hs
+++ b/test/DecomposeFormulaSpec.hs
@@ -12,11 +12,13 @@ import Test.QuickCheck
 import SynTreeSpec (validBoundsSynTree)
 import Tasks.SynTree.Config (SynTreeConfig(..))
 import Control.Monad.Output (LangM)
-import Data.Maybe (isJust)
+import Data.Maybe (isJust, fromJust)
 import Control.Monad.Identity (Identity(runIdentity))
 import Control.Monad.Output.Generic (evalLangM)
 import Tasks.DecomposeFormula.Quiz (generateDecomposeFormulaInst)
-import Trees.Helpers (bothKids)
+import Trees.Helpers (bothKids, binOp)
+import Trees.Types (SynTree(..))
+import Trees.Print (display)
 
 validBoundsDecomposeFormula :: Gen DecomposeFormulaConfig
 validBoundsDecomposeFormula = do
@@ -41,4 +43,6 @@ spec = do
     it "should generate an instance with different subtrees" $
       forAll validBoundsDecomposeFormula $ \decomposeFormulaConfig ->
         forAll (generateDecomposeFormulaInst decomposeFormulaConfig) $ \DecomposeFormulaInst{..} ->
-          let (lk,rk) = bothKids tree in lk /= rk
+          let (lk,rk) = bothKids tree
+              rootOp = fromJust $ binOp tree
+          in notElem (display (Binary rootOp lk rk)) [display (Binary rootOp rk lk), reverse (display (Binary rootOp lk rk))]

--- a/test/DecomposeFormulaSpec.hs
+++ b/test/DecomposeFormulaSpec.hs
@@ -21,7 +21,7 @@ import Trees.Helpers (bothKids)
 validBoundsDecomposeFormula :: Gen DecomposeFormulaConfig
 validBoundsDecomposeFormula = do
   syntaxTreeConfig <- validBoundsSynTree `suchThat` \SynTreeConfig{..} ->
-    minUniqueBinOperators >= 1 && minNodes >= 2 * minUniqueBinOperators + 3
+    minUniqueBinOperators >= 1
   return DecomposeFormulaConfig {
     syntaxTreeConfig,
     extraHintsOnAssociativity = False,

--- a/test/DecomposeFormulaSpec.hs
+++ b/test/DecomposeFormulaSpec.hs
@@ -23,7 +23,7 @@ import Trees.Print (display)
 validBoundsDecomposeFormula :: Gen DecomposeFormulaConfig
 validBoundsDecomposeFormula = do
   syntaxTreeConfig <- validBoundsSynTree `suchThat` \SynTreeConfig{..} ->
-    minUniqueBinOperators >= 1
+    minUniqueBinOperators >= 1 && minNodes > 6
   return DecomposeFormulaConfig {
     syntaxTreeConfig,
     extraHintsOnAssociativity = False,

--- a/test/DecomposeFormulaSpec.hs
+++ b/test/DecomposeFormulaSpec.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
+module DecomposeFormulaSpec where
+
+import Test.Hspec
+import Tasks.DecomposeFormula.Config (DecomposeFormulaConfig(..), checkDecomposeFormulaConfig, defaultDecomposeFormulaConfig, DecomposeFormulaInst(..))
+import Test.QuickCheck
+import SynTreeSpec (validBoundsSynTree)
+import Tasks.SynTree.Config (SynTreeConfig(..))
+import Control.Monad.Output (LangM)
+import Data.Maybe (isJust)
+import Control.Monad.Identity (Identity(runIdentity))
+import Control.Monad.Output.Generic (evalLangM)
+import Tasks.DecomposeFormula.Quiz (generateDecomposeFormulaInst)
+import Trees.Helpers (bothKids)
+
+validBoundsDecomposeFormula :: Gen DecomposeFormulaConfig
+validBoundsDecomposeFormula = do
+  syntaxTreeConfig <- validBoundsSynTree `suchThat` \SynTreeConfig{..} ->
+    minUniqueBinOperators >= 1 && minNodes >= 2 * minUniqueBinOperators + 3
+  return DecomposeFormulaConfig {
+    syntaxTreeConfig,
+    extraHintsOnAssociativity = False,
+    extraText = Nothing,
+    printSolution = False
+  }
+
+spec :: Spec
+spec = do
+  describe "config" $ do
+    it "default config should pass config check" $
+      isJust $ runIdentity $ evalLangM (checkDecomposeFormulaConfig defaultDecomposeFormulaConfig :: LangM Maybe)
+    it "validBoundsDecomposeFormula should generate a valid config" $
+      forAll validBoundsDecomposeFormula $ \decomposeFormulaConfig ->
+        isJust $ runIdentity $ evalLangM (checkDecomposeFormulaConfig decomposeFormulaConfig :: LangM Maybe)
+  describe "generateDecomposeFormulaInst" $ do
+    it "should generate an instance with different subtrees" $
+      forAll validBoundsDecomposeFormula $ \decomposeFormulaConfig ->
+        forAll (generateDecomposeFormulaInst decomposeFormulaConfig) $ \DecomposeFormulaInst{..} ->
+          let (lk,rk) = bothKids tree in lk /= rk

--- a/test/SynTreeSpec.hs
+++ b/test/SynTreeSpec.hs
@@ -71,7 +71,7 @@ spec = do
         forAll (genSynTree synTreeConfig) $ \tree -> formulaParse (tail (display tree)) /= Right tree
   describe "numOfUniqueBinOpsInSynTree" $ do
         it "should return 0 if there is only a leaf" $
-            numOfUniqueBinOpsInSynTree (Leaf 'a') == 0
+            numOfUniqueBinOpsInSynTree @BinOp (Leaf 'a') == 0
         it "should return 1 if there is only one operator" $
             numOfUniqueBinOpsInSynTree (Binary Or (Leaf 'a') (Leaf 'b')) == 1
         it "should return 1 if there are two operators of same kind" $


### PR DESCRIPTION
Fügt den Aufgabentyp `DecomposeFormula` wie in #112 beschrieben ein. Analog zu `ComposeFormula` werden erstmal keine Pfeiloperatoren benutzt.