### PR TITLE
make Delayed type abstract

### DIFF
--- a/src/Formula/Parsing/Delayed.hs
+++ b/src/Formula/Parsing/Delayed.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE DeriveGeneric #-}
-module Formula.Parsing.Delayed (Delayed, delayed, unDelayed, parseDelayed, withDelayed) where
+module Formula.Parsing.Delayed (Delayed, delayed, parseDelayed, parseDelayedRaw, withDelayed) where
 
 
 import Text.Parsec
@@ -14,17 +14,23 @@ import LogicTasks.Helpers (reject)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 
-newtype Delayed a = Delayed {unDelayed :: String} deriving (Eq, Typeable, Generic)
+newtype Delayed a = Delayed String deriving (Eq, Typeable, Generic)
+
+instance Show (Delayed a) where
+  show (Delayed str) = str
 
 delayed :: String -> Delayed a
 delayed = Delayed
 
-parseDelayed :: Delayed a -> Parser a -> Either ParseError a
-parseDelayed (Delayed str) p = parse p "(delayed input)" str
+parseDelayed :: Parser a -> Delayed a -> Either ParseError a
+parseDelayed = parseDelayedRaw
+
+parseDelayedRaw :: Parser b -> Delayed a -> Either ParseError b
+parseDelayedRaw p (Delayed str) = parse p "(answer string)" str
 
 withDelayed :: OutputMonad m => (a -> LangM m) -> Parser a -> Delayed a -> LangM m
 withDelayed grade p d =
-  case parseDelayed d (fully p) of
+  case parseDelayed (fully p) d of
     Left err -> reject $ do
       english $ show err
       german $ show err

--- a/src/Formula/Parsing/Delayed.hs
+++ b/src/Formula/Parsing/Delayed.hs
@@ -16,9 +16,6 @@ import GHC.Generics (Generic)
 
 newtype Delayed a = Delayed String deriving (Eq, Typeable, Generic)
 
-instance Show (Delayed a) where
-  show (Delayed str) = str
-
 delayed :: String -> Delayed a
 delayed = Delayed
 

--- a/src/Formula/Parsing/Delayed.hs
+++ b/src/Formula/Parsing/Delayed.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE DeriveGeneric #-}
-module Formula.Parsing.Delayed where
+module Formula.Parsing.Delayed (Delayed, delayed, unDelayed, parseDelayed, withDelayed) where
 
 
 import Text.Parsec
@@ -14,7 +14,7 @@ import LogicTasks.Helpers (reject)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 
-newtype Delayed a = Delayed String deriving (Eq, Show, Typeable, Generic)
+newtype Delayed a = Delayed {unDelayed :: String} deriving (Eq, Typeable, Generic)
 
 delayed :: String -> Delayed a
 delayed = Delayed

--- a/src/Formula/Parsing/Delayed.hs
+++ b/src/Formula/Parsing/Delayed.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE DeriveGeneric #-}
 module Formula.Parsing.Delayed (Delayed, delayed, parseDelayed, parseDelayedRaw, withDelayed) where
-
 
 import Text.Parsec
 import Text.Parsec.String (Parser)
@@ -11,10 +9,7 @@ import Control.Monad.Output (LangM, english, german, OutputMonad)
 
 import LogicTasks.Helpers (reject)
 
-import Data.Typeable (Typeable)
-import GHC.Generics (Generic)
-
-newtype Delayed a = Delayed String deriving (Eq, Typeable, Generic)
+newtype Delayed a = Delayed String
 
 delayed :: String -> Delayed a
 delayed = Delayed

--- a/src/LogicTasks/Syntax/TreeToFormula.hs
+++ b/src/LogicTasks/Syntax/TreeToFormula.hs
@@ -27,10 +27,9 @@ import Formula.Util (isSemanticEqual)
 import Control.Monad (when)
 import Trees.Print (transferToPicture)
 import Tasks.TreeToFormula.Config (TreeToFormulaInst(..))
-import Formula.Parsing.Delayed (Delayed, unDelayed, withDelayed, parseDelayed)
+import Formula.Parsing.Delayed (Delayed, withDelayed, parseDelayed, parseDelayedRaw)
 import Formula.Parsing (Parse(..))
 import Trees.Parsing()
-import Text.Parsec (parse)
 import UniversalParser (tokenSequence)
 import ParsingHelpers (fully)
 
@@ -79,9 +78,9 @@ start = TreeFormulaAnswer Nothing
 
 partialGrade :: OutputMonad m => TreeToFormulaInst -> Delayed TreeFormulaAnswer -> LangM m
 partialGrade inst ans =
-  case parseDelayed ans (fully $ parser @TreeFormulaAnswer) of
+  case parseDelayed (fully $ parser @TreeFormulaAnswer) ans of
     Right f -> partialGrade' inst f
-    Left err -> reject $ case parse (fully tokenSequence) "" (unDelayed ans) of
+    Left err -> reject $ case parseDelayedRaw (fully tokenSequence) ans of
       Left _ -> do
         german $ show err
         english $ show err

--- a/src/LogicTasks/Syntax/TreeToFormula.hs
+++ b/src/LogicTasks/Syntax/TreeToFormula.hs
@@ -27,7 +27,7 @@ import Formula.Util (isSemanticEqual)
 import Control.Monad (when)
 import Trees.Print (transferToPicture)
 import Tasks.TreeToFormula.Config (TreeToFormulaInst(..))
-import Formula.Parsing.Delayed (Delayed (..), withDelayed)
+import Formula.Parsing.Delayed (Delayed, unDelayed, withDelayed, parseDelayed)
 import Formula.Parsing (Parse(..))
 import Trees.Parsing()
 import Text.Parsec (parse)
@@ -78,10 +78,10 @@ start :: TreeFormulaAnswer
 start = TreeFormulaAnswer Nothing
 
 partialGrade :: OutputMonad m => TreeToFormulaInst -> Delayed TreeFormulaAnswer -> LangM m
-partialGrade inst (Delayed ans) =
-  case parse (fully $ parser @TreeFormulaAnswer) "(delayed input)" ans of
+partialGrade inst ans =
+  case parseDelayed ans (fully $ parser @TreeFormulaAnswer) of
     Right f -> partialGrade' inst f
-    Left err -> case parse (fully tokenSequence) "" ans of
+    Left err -> case parse (fully tokenSequence) "" (unDelayed ans) of
       Left _ -> reject $ do
         german $ show err
         english $ show err


### PR DESCRIPTION
@owestphal, wouldn't it be better to hide the data constructor of the `newtype` thus?

I've also been thinking about further replacing
```haskell
newtype Delayed a = Delayed {unDelayed :: String} deriving (Eq, Typeable, Generic)
```
by
```haskell
newtype Delayed a = Delayed String deriving (Eq, Typeable, Generic)

instance Show (Delayed a) where
  show (Delayed str) = str
```
and
```haskell
    Left err -> reject $ case parse (fully tokenSequence) "" (unDelayed ans) of
```
by
```haskell
    Left err -> reject $ case parse (fully tokenSequence) "" (show ans) of
```

Is there a need somewhere to really have the default derived `Show` instance for `Delayed`, i.e., with `"Delayed "` being output?
