### PR TITLE
Backwards implication operator

### DIFF
--- a/src/Formula/Parsing.hs
+++ b/src/Formula/Parsing.hs
@@ -159,7 +159,7 @@ instance FromGrammar Literal where
     , allowAnd = False
     , allowNegation = LiteralsOnly
     , allowAtomicProps = True
-    , allowImplication = False
+    , allowImplication = NoImplication
     , strictParens = False
     , allowBiImplication = False
     , allowSilentNesting = False
@@ -179,7 +179,7 @@ instance FromGrammar Clause where
     , allowAnd = False
     , allowNegation = LiteralsOnly
     , allowAtomicProps = True
-    , allowImplication = False
+    , allowImplication = NoImplication
     , allowBiImplication = False
     , strictParens = False
     , allowSilentNesting = False
@@ -205,7 +205,7 @@ instance FromGrammar Con where
     , allowAnd = True
     , allowNegation = LiteralsOnly
     , allowAtomicProps = True
-    , allowImplication = False
+    , allowImplication = NoImplication
     , allowBiImplication = False
     , strictParens = False
     , allowSilentNesting = False

--- a/src/LogicTasks/Helpers.hs
+++ b/src/LogicTasks/Helpers.hs
@@ -130,7 +130,7 @@ arrowsKey = do
     translate $ do
       english "Implication:"
       german "Implikation:"
-    code "=>"
+    code "=>, <="
     pure ()
   paragraph $ indent $ do
     translate $ do

--- a/src/Tasks/LegalCNF/GenerateIllegal.hs
+++ b/src/Tasks/LegalCNF/GenerateIllegal.hs
@@ -86,7 +86,7 @@ genIllegalClauseShape ifFirstLayer allowArrowOperators ors = do
     if ifUseError
     then  if allowArrowOperators
           then oneof [ return (Not (legalShape Or ors))
-                     , genIllegalOperator (legalShape Or) (Equi : Impl : [And | not ifFirstLayer]) ors
+                     , genIllegalOperator (legalShape Or) (Equi : Impl : BackImpl : [And | not ifFirstLayer]) ors
                      ]
           else  if ifFirstLayer
                 then return (Not (legalShape Or ors))

--- a/src/Trees/Parsing.hs
+++ b/src/Trees/Parsing.hs
@@ -33,7 +33,7 @@ instance FromGrammar (SynTree BinOp Char) where
       , allowAnd = True
       , allowNegation = Everywhere
       , allowAtomicProps = True
-      , allowImplication = True
+      , allowImplication = Forwards
       , allowBiImplication = True
       , strictParens = True
       , allowSilentNesting = False
@@ -80,7 +80,7 @@ instance FromGrammar (PropFormula Char) where
       , allowAnd = True
       , allowNegation = Everywhere
       , allowAtomicProps = True
-      , allowImplication = True
+      , allowImplication = Forwards
       , allowBiImplication = True
       , strictParens = False
       , allowSilentNesting = False
@@ -95,6 +95,7 @@ instance FromGrammar (PropFormula Char) where
       fromAnds (Ands f g) = Assoc Formula.And <$> fromAnds f <*> fromImpls g
       fromAnds (OfImpl f) = fromImpls f
       fromImpls (Impls f g) = Assoc Formula.Impl <$> fromBiImpls f <*> fromImpls g
+      fromImpls (BackImpls f g) = Assoc Formula.BackImpl <$> fromBiImpls f <*> fromImpls g
       fromImpls (OfBiImpl f) = fromBiImpls f
       fromBiImpls (BiImpls f g) = Assoc Equi <$> fromNeg f <*> fromBiImpls g
       fromBiImpls (OfNeg f) = fromNeg f

--- a/src/Trees/Parsing.hs
+++ b/src/Trees/Parsing.hs
@@ -50,6 +50,7 @@ instance FromGrammar (SynTree BinOp Char) where
       fromOp Parser.Or = Formula.Or
       fromOp Parser.And = Formula.And
       fromOp Parser.Impl = Formula.Impl
+      fromOp Parser.BackImpl = Formula.BackImpl
       fromOp BiImpl = Equi
       fromNeg :: Neg -> Maybe (SynTree BinOp Char)
       fromNeg (NegAtom (Atom x)) = Just $ Not $ Leaf x

--- a/src/Trees/Parsing.hs
+++ b/src/Trees/Parsing.hs
@@ -33,7 +33,7 @@ instance FromGrammar (SynTree BinOp Char) where
       , allowAnd = True
       , allowNegation = Everywhere
       , allowAtomicProps = True
-      , allowImplication = Forwards
+      , allowImplication = Both
       , allowBiImplication = True
       , strictParens = True
       , allowSilentNesting = False
@@ -80,7 +80,7 @@ instance FromGrammar (PropFormula Char) where
       , allowAnd = True
       , allowNegation = Everywhere
       , allowAtomicProps = True
-      , allowImplication = Forwards
+      , allowImplication = Both
       , allowBiImplication = True
       , strictParens = False
       , allowSilentNesting = False

--- a/src/Trees/Print.hs
+++ b/src/Trees/Print.hs
@@ -14,6 +14,7 @@ transferToPicture (Binary Or a b) = "[ $\\vee   $ " ++ transferToPicture a ++ tr
 transferToPicture (Not a) = "[ $\\neg $ " ++ transferToPicture a ++ "  ]"
 transferToPicture (Binary Impl a b) = "[ $\\Rightarrow  $ " ++ transferToPicture a ++ transferToPicture b ++ "  ]"
 transferToPicture (Binary Equi a b) = "[ $\\Leftrightarrow  $ " ++ transferToPicture a ++ transferToPicture b ++"  ]"
+transferToPicture (Binary BackImpl a b) = "[ $\\Leftarrow  $ " ++ transferToPicture a ++ transferToPicture b ++ "  ]"
 
 display :: SynTree BinOp Char -> String
 display (Binary operator a b) = normalShow a ++ " " ++ showOperator operator ++ " " ++ normalShow b

--- a/src/UniversalParser.hs
+++ b/src/UniversalParser.hs
@@ -46,7 +46,7 @@ data NoFixity = NoFixity Basic Op Basic | OfBasic Basic
 data Basic = BasicNested Nested | BasicNeg Neg
   deriving Show
 
-data Op = Or | And | Impl | BiImpl
+data Op = Or | And | Impl | BackImpl | BiImpl
   deriving Show
 
 data Ors = Ors Ors Ands | OfAnds Ands
@@ -212,6 +212,7 @@ formula LevelSpec{..}
         Or -> "Disjunction"
         And -> "Conjunction"
         Impl -> "Implication"
+        BackImpl -> "(Back)-Implication"
         BiImpl -> "Bi-Implication")
       <|> pure ()
 

--- a/src/UniversalParser.hs
+++ b/src/UniversalParser.hs
@@ -24,7 +24,7 @@ import ParsingHelpers
   -- with precedence
   Ors ::= Ors ∨ Ands | Ands
   Ands ::= Ands ∧ Impl | Impl
-  Impl ::= BiImpl => Impl | BiImpl
+  Impl ::= BiImpl => Impl | BiImpl <= Impl | BiImpl
   BiImpl ::= Neg <=> BiImpl | Neg
 
   -- 'leaf' formulas
@@ -132,7 +132,7 @@ data LevelSpec = LevelSpec
   , nextLevelSpec :: Maybe LevelSpec
   }
 
-data AllowImplication = NoImplication | Forwards | Backwards deriving Eq
+data AllowImplication = NoImplication | Forwards | Backwards | Both deriving Eq
 data AllowNegation = Nowhere | LiteralsOnly | Everywhere
 
 -- parser for operations
@@ -243,7 +243,8 @@ formula LevelSpec{..}
   impl
     = case allowImplication of
       Forwards -> infixr1 OfBiImpl biImpl (implicationParser $> Impls)
-      Backwards -> infixl1 OfBiImpl biImpl (backImplicationParser $> flip BackImpls)
+      Backwards -> infixr1 OfBiImpl biImpl (backImplicationParser $> BackImpls)
+      Both -> infixr1 OfBiImpl biImpl (implicationParser $> Impls <|> backImplicationParser $> BackImpls)
       NoImplication -> OfBiImpl <$> biImpl
 
   biImpl :: Parser BiImpls


### PR DESCRIPTION
Partial implementation of #29. The `UniversalParser` still needs some updates. For that, we need to decide whether `=>` or `<=` has a higher precedence.

```
(A => B <= C) <=> (A => B) <= C
```
or
```
(A => B <= C) <=> A => (B <= C)
```
or completely disallow the use of `<=` without parentheses.