### PR TITLE
fix incompatible import of liftIO with 9.8.1

### DIFF
--- a/src/LogicTasks/Syntax/DecomposeFormula.hs
+++ b/src/LogicTasks/Syntax/DecomposeFormula.hs
@@ -5,6 +5,7 @@
 module LogicTasks.Syntax.DecomposeFormula where
 
 
+import Control.Monad.IO.Class (MonadIO (liftIO))
 import Control.Monad.Output (
   LangM,
   OutputMonad, german, english,
@@ -19,7 +20,6 @@ import Control.Monad (when, unless)
 import Data.Maybe (isNothing, fromJust)
 import Trees.Helpers (collectLeaves, collectUniqueBinOpsInSynTree, swapKids)
 import Data.Containers.ListUtils (nubOrd)
-import Control.Monad.Cont (MonadIO (liftIO))
 import LogicTasks.Syntax.TreeToFormula (cacheTree)
 import Formula.Parsing (Parse(parser))
 import Formula.Parsing.Delayed (Delayed, withDelayed, parseDelayedAndThen, complainAboutMissingParenthesesIfNotFailingOn)


### PR DESCRIPTION
The import of liftIO caused Autotool to not compile since it has been removed in later versions of the package.