### PR TITLE
`output-blocks` in `LogicTasks.Debug` nutzen

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,0 +1,1 @@
+:m + Control.OutputCapable.Blocks Control.OutputCapable.Blocks.Debug

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can use the `testModule` function in order to test a module. A sample call l
 
 ```text
 $ stack repl
-ghci> testModule (Just AutoLeijen) German (genResInst dResConf) LogicTasks.Semantics.Resolve.description LogicTasks.Semantics.Resolve.partialGrade LogicTasks.Semantics.Resolve.completeGrade parser
+ghci> testModule (Just (Manual show)) German (genResInst dResConf) LogicTasks.Semantics.Resolve.description LogicTasks.Semantics.Resolve.partialGrade LogicTasks.Semantics.Resolve.completeGrade parser
 ```
 
 This specific call tests the `Resolve` module (found in `src/LogicTasks/Semantics/Resolve.hs`). The output looks like this:
@@ -81,7 +81,7 @@ Nothing
 
 In more detail:
 
-- We passed `Just (AutoLeijen)` to format the input with the specified pretty printer. Other options are: `Nothing`, `Just (AutoHughesPJ)` or `Just (Manual f)` where f is of type `a -> String`.
+- We passed `Just (Manual show)` to format the input with the specified pretty printer (which is the default `show` here since we are testing a `Delayed` task). Other options are: `Nothing`, `Just AutoLeijen` or `Just AutoHughesPJ`.
 - We passed `German` to print the german version of the task. The other option would be `English`.
 - We then passed the generator for creating an instance of the specified module. Must be of type `Gen a`.
 - Furthermore, we pass the function that prints the task description. This is usually `SomeModulePath.description`.

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@
 
 You can use the `testModule` function in order to test a module. A sample call looks like this:
 
-```
+```text
 $ stack repl
 ghci> testModule (Just AutoLeijen) German (genResInst dResConf) LogicTasks.Semantics.Resolve.description LogicTasks.Semantics.Resolve.partialGrade LogicTasks.Semantics.Resolve.completeGrade parser
 ```
 
 This specific call tests the `Resolve` module (found in `src/LogicTasks/Semantics/Resolve.hs`). The output looks like this:
 
-```
+```text
 Betrachten Sie die folgende Formel in KNF:>>>> <¬D ∧ (¬A ∨ D) ∧ (A ∨ D)> <<<<
 
 Führen Sie das Resolutionsverfahren an dieser Formel durch, um die leere Klausel abzuleiten.
@@ -80,11 +80,11 @@ Nothing
 ```
 
 In more detail:
-  
+
 - We passed `Just (AutoLeijen)` to format the input with the specified pretty printer. Other options are: `Nothing`, `Just (AutoHughesPJ)` or `Just (Manual f)` where f is of type `(a -> String) -> Display a`.
 - We passed `German` to print the german version of the task. The other option would be `English`.
 - We then passed the generator for creating an instance of the specified module. Must be of type `Gen a`.
-- Furthermore, we pass the function that prints the task description. This is usually `SomeModulePath.description`. 
+- Furthermore, we pass the function that prints the task description. This is usually `SomeModulePath.description`.
 - Next, we pass the function that checks the input for syntax errors. This is usually `SomeModulePath.partialGrade`.
 - Then, we pass the function that checks the input for semantic errors. This is usually `SomeModulePath.completeGrade`.
 - Lastly, we pass a parser that allows us to parse the users input. This is usually just `parser`. Must be of type `Parser b`, if you define one yourself.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Neu resolvierte Klauseln können mit einer Nummer versehen werden, indem Sie '= 
 Just ()
 [({-D},{-A,D},{-A})]
 ---- Input ----
-"[({-D},{-A,D},{-A})]"
+[({-D},{-A,D},{-A})]
 ---- Prettified Input ----
 [({-D},{-A,D},{-A})]
 ---- Partial ----
@@ -81,7 +81,7 @@ Nothing
 
 In more detail:
 
-- We passed `Just (AutoLeijen)` to format the input with the specified pretty printer. Other options are: `Nothing`, `Just (AutoHughesPJ)` or `Just (Manual f)` where f is of type `(a -> String) -> Display a`.
+- We passed `Just (AutoLeijen)` to format the input with the specified pretty printer. Other options are: `Nothing`, `Just (AutoHughesPJ)` or `Just (Manual f)` where f is of type `a -> String`.
 - We passed `German` to print the german version of the task. The other option would be `English`.
 - We then passed the generator for creating an instance of the specified module. Must be of type `Gen a`.
 - Furthermore, we pass the function that prints the task description. This is usually `SomeModulePath.description`.

--- a/README.md
+++ b/README.md
@@ -26,62 +26,66 @@ You can use the `testModule` function in order to test a module. A sample call l
 
 ```text
 $ stack repl
-ghci> testModule (Just (Manual show)) German (genResInst dResConf) LogicTasks.Semantics.Resolve.description LogicTasks.Semantics.Resolve.partialGrade LogicTasks.Semantics.Resolve.completeGrade parser
+ghci> testModule (Just AutoLeijen) German (genFillInst dFillConf) LogicTasks.Semantics.Fill.description LogicTasks.Semantics.Fill.partialGrade LogicTasks.Semantics.Fill.completeGrade parser
 ```
 
-This specific call tests the `Resolve` module (found in `src/LogicTasks/Semantics/Resolve.hs`). The output looks like this:
+This specific call tests the `Fill` module (found in `src/LogicTasks/Semantics/Fill.hs`). The output looks like this:
 
 ```text
-Betrachten Sie die folgende Formel in KNF:>>>> <¬D ∧ (¬A ∨ D) ∧ (A ∨ D)> <<<<
+Betrachten Sie die folgende Formel:>>>> <F = (¬A ∨ ¬B) ∧ (A ∨ B) ∧ (B ∨ ¬C) ∧ (A ∨ B ∨ D)> <<<<
 
-Führen Sie das Resolutionsverfahren an dieser Formel durch, um die leere Klausel abzuleiten.
-Geben Sie die Lösung als eine Liste von Tripeln an, wobei diese folgendermaßen aufgebaut sind: (Erste Klausel, Zweite Klausel, Resolvente)
-Beachten Sie dabei die folgenden möglichen Schreibweisen:
->>>>Negation: <-, ~, nicht> <<<<
+Füllen Sie in der zugehörigen Wahrheitstafel alle Lücken mit einem passenden Wahrheitswert (Wahr oder Falsch).>>>> <A | B | C | D | F
+--|---|---|---|--
+0 | 0 | 0 | 0 | 0
+0 | 0 | 0 | 1 | -
+0 | 0 | 1 | 0 | 0
+0 | 0 | 1 | 1 | 0
+0 | 1 | 0 | 0 | 1
+0 | 1 | 0 | 1 | -
+0 | 1 | 1 | 0 | 1
+0 | 1 | 1 | 1 | -
+1 | 0 | 0 | 0 | -
+1 | 0 | 0 | 1 | 1
+1 | 0 | 1 | 0 | 0
+1 | 0 | 1 | 1 | -
+1 | 1 | 0 | 0 | 0
+1 | 1 | 0 | 1 | 0
+1 | 1 | 1 | 0 | -
+1 | 1 | 1 | 1 | 0
 
->>>>Nicht-leere Klausel: <{ ... }> <<<<
+> <<<<
 
->>>>Leere Klausel: <{ }> <<<<
-
-Optional können Sie Klauseln auch durch Nummern ersetzen.
-Klauseln aus der Formel sind bereits ihrer Reihenfolge nach nummeriert. (erste Klausel = 1, zweite Klausel = 2, ...).
-Neu resolvierte Klauseln können mit einer Nummer versehen werden, indem Sie '= NUMMER' an diese anfügen.
->>>>Ein Lösungsversuch könnte beispielsweise so aussehen:  <[(1, 2, {A, nicht B} = 5), (4, 5, { })]> <<<<
+Geben Sie als Lösung eine Liste der fehlenden Wahrheitswerte an, wobei das erste Element der Liste der ersten Lücke von oben entspricht, das zweite Element der zweiten Lücke, etc.
+Die Eingabe der Werte kann binär (0 = falsch, 1 = wahr), ausgeschrieben (falsch, wahr) oder als Kurzform (f, w) erfolgen.
+>>>>Ein Lösungsversuch im Fall von vier Lücken könnte beispielsweise so aussehen: <[0,1,1,1]> <<<<
 
 Just ()
-[({-D},{-A,D},{-A})]
+[0,1,1,1,0,1]
 ---- Input ----
-[({-D},{-A,D},{-A})]
+[TruthValue {truth = False},TruthValue {truth = True},TruthValue {truth = True},TruthValue {truth = True},TruthValue {truth = False},TruthValue {truth = True}]
 ---- Prettified Input ----
-[({-D},{-A,D},{-A})]
+[False
+,True
+,True
+,True
+,False
+,True]
 ---- Partial ----
-1. Schritt verwendet nur existierende Indizes?
+Lösung hat korrekte Länge?
 >>>> <Ja.> <<<<
 
-1. Schritt vergibt keinen Index wiederholt?
->>>> <Ja.> <<<<
-
-Genutzte Literale kommen in Formel vor?
->>>> <Ja.> <<<<
-
-Alle Schritte sind gültig?
->>>> <Ja.> <<<<
-
-Letzter Schritt leitet die leere Klausel ab?
->>>> <Nein.> <<<<
-
-Nothing
-!!! The following would not be printed in Autotool !!!
+Just ()
 ---- Complete ----
 Lösung ist korrekt?
 >>>> <Nein.> <<<<
 
+>>>>Die Lösung beinhaltet 1 Fehler.<<<<
 Nothing
 ```
 
 In more detail:
 
-- We passed `Just (Manual show)` to format the input with the specified pretty printer (which is the default `show` here since we are testing a `Delayed` task). Other options are: `Nothing`, `Just AutoLeijen` or `Just AutoHughesPJ`.
+- We passed `Just AutoLeijen` to format the input with the specified pretty printer. Other options are: `Nothing`, `Just AutoHughesPJ` or `Manual f` where f is of type `a -> String`. Note that only `Nothing` makes sense for tasks using `Delayed`.
 - We passed `German` to print the german version of the task. The other option would be `English`.
 - We then passed the generator for creating an instance of the specified module. Must be of type `Gen a`.
 - Furthermore, we pass the function that prints the task description. This is usually `SomeModulePath.description`.

--- a/README.md
+++ b/README.md
@@ -19,3 +19,72 @@
 | Aussagenlogik/Semantik/Resolution/LogicResolutionStep | x | x | `Logic.Semantics.ResolutionStep` | [`LogicTasks.Semantics.Step`](src/LogicTasks/Semantics/Step.hs) |
 | Aussagenlogik/Semantik/Resolution/LogicResolutionComplete | x | x | `Logic.Semantics.ResolutionFull` | [`LogicTasks.Semantics.Resolve`](src/LogicTasks/Semantics/Resolve.hs) |
 | Aussagenlogik/Semantik/Resolution/PrologResolutionStep | x | x | `Logic.Semantics.ResolutionStepProlog` | [`LogicTasks.Semantics.Prolog`](src/LogicTasks/Semantics/Prolog.hs) |
+
+## Testing a module
+
+You can use the `testModule` function in order to test a module. A sample call looks like this:
+
+```
+$ stack repl
+ghci> testModule (Just AutoLeijen) German (genResInst dResConf) LogicTasks.Semantics.Resolve.description LogicTasks.Semantics.Resolve.partialGrade LogicTasks.Semantics.Resolve.completeGrade parser
+```
+
+This specific call tests the `Resolve` module (found in `src/LogicTasks/Semantics/Resolve.hs`). The output looks like this:
+
+```
+Betrachten Sie die folgende Formel in KNF:>>>> <¬D ∧ (¬A ∨ D) ∧ (A ∨ D)> <<<<
+
+Führen Sie das Resolutionsverfahren an dieser Formel durch, um die leere Klausel abzuleiten.
+Geben Sie die Lösung als eine Liste von Tripeln an, wobei diese folgendermaßen aufgebaut sind: (Erste Klausel, Zweite Klausel, Resolvente)
+Beachten Sie dabei die folgenden möglichen Schreibweisen:
+>>>>Negation: <-, ~, nicht> <<<<
+
+>>>>Nicht-leere Klausel: <{ ... }> <<<<
+
+>>>>Leere Klausel: <{ }> <<<<
+
+Optional können Sie Klauseln auch durch Nummern ersetzen.
+Klauseln aus der Formel sind bereits ihrer Reihenfolge nach nummeriert. (erste Klausel = 1, zweite Klausel = 2, ...).
+Neu resolvierte Klauseln können mit einer Nummer versehen werden, indem Sie '= NUMMER' an diese anfügen.
+>>>>Ein Lösungsversuch könnte beispielsweise so aussehen:  <[(1, 2, {A, nicht B} = 5), (4, 5, { })]> <<<<
+
+Just ()
+[({-D},{-A,D},{-A})]
+---- Input ----
+"[({-D},{-A,D},{-A})]"
+---- Prettified Input ----
+[({-D},{-A,D},{-A})]
+---- Partial ----
+1. Schritt verwendet nur existierende Indizes?
+>>>> <Ja.> <<<<
+
+1. Schritt vergibt keinen Index wiederholt?
+>>>> <Ja.> <<<<
+
+Genutzte Literale kommen in Formel vor?
+>>>> <Ja.> <<<<
+
+Alle Schritte sind gültig?
+>>>> <Ja.> <<<<
+
+Letzter Schritt leitet die leere Klausel ab?
+>>>> <Nein.> <<<<
+
+Nothing
+!!! The following would not be printed in Autotool !!!
+---- Complete ----
+Lösung ist korrekt?
+>>>> <Nein.> <<<<
+
+Nothing
+```
+
+In more detail:
+  
+- We passed `Just (AutoLeijen)` to format the input with the specified pretty printer. Other options are: `Nothing`, `Just (AutoHughesPJ)` or `Just (Manual f)` where f is of type `(a -> String) -> Display a`.
+- We passed `German` to print the german version of the task. The other option would be `English`.
+- We then passed the generator for creating an instance of the specified module. Must be of type `Gen a`.
+- Furthermore, we pass the function that prints the task description. This is usually `SomeModulePath.description`. 
+- Next, we pass the function that checks the input for syntax errors. This is usually `SomeModulePath.partialGrade`.
+- Then, we pass the function that checks the input for semantic errors. This is usually `SomeModulePath.completeGrade`.
+- Lastly, we pass a parser that allows us to parse the users input. This is usually just `parser`. Must be of type `Parser b`, if you define one yourself.

--- a/examples/src/Semantics/Resolution/Complete/Config.hs
+++ b/examples/src/Semantics/Resolution/Complete/Config.hs
@@ -7,6 +7,7 @@ import LogicTasks.Config (
 import Test.Hspec
 import Util.VerifyConfig
 import LogicTasks.Util (checkBaseConf)
+import Control.OutputCapable.Blocks (Language(German))
 
 -- Weight 0.5
 task15 :: ResolutionConfig
@@ -38,5 +39,5 @@ task16 =  ResolutionConfig
 
 spec :: Spec
 spec = do
-  describe "task15" $ verifyConfig (baseConf task15) checkBaseConf
-  describe "task16" $ verifyConfig (baseConf task16) checkBaseConf
+  describe "task15" $ verifyConfig German (baseConf task15) checkBaseConf
+  describe "task16" $ verifyConfig German (baseConf task16) checkBaseConf

--- a/examples/src/Semantics/Resolution/Step/Config.hs
+++ b/examples/src/Semantics/Resolution/Step/Config.hs
@@ -7,6 +7,7 @@ import LogicTasks.Config (
 import LogicTasks.Util (checkBaseConf)
 import Test.Hspec
 import Util.VerifyConfig
+import Control.OutputCapable.Blocks (Language(German))
 
 -- Weight 0.2
 task12 :: StepConfig
@@ -40,5 +41,5 @@ task14 =
 
 spec :: Spec
 spec = do
-  describe "task12" $ verifyConfig (baseConf task12) checkBaseConf
-  describe "task14" $ verifyConfig (baseConf task14) checkBaseConf
+  describe "task12" $ verifyConfig German (baseConf task12) checkBaseConf
+  describe "task14" $ verifyConfig German (baseConf task14) checkBaseConf

--- a/examples/src/Semantics/TruthTables/ChooseForFormula/Config.hs
+++ b/examples/src/Semantics/TruthTables/ChooseForFormula/Config.hs
@@ -9,6 +9,7 @@ import LogicTasks.Util (checkCnfConf)
 
 import Test.Hspec
 import Util.VerifyConfig
+import Control.OutputCapable.Blocks (Language(German))
 
 -- Weight 0.33
 task08 :: PickConfig
@@ -48,5 +49,5 @@ task19 = PickConfig
 
 spec :: Spec
 spec = do
-  describe "task08" $ verifyConfig (cnfConf task08) checkCnfConf
-  describe "task19" $ verifyConfig (cnfConf task19) checkCnfConf
+  describe "task08" $ verifyConfig German (cnfConf task08) checkCnfConf
+  describe "task19" $ verifyConfig German (cnfConf task19) checkCnfConf

--- a/examples/src/Semantics/TruthTables/FillGaps/Config.hs
+++ b/examples/src/Semantics/TruthTables/FillGaps/Config.hs
@@ -8,6 +8,7 @@ import LogicTasks.Config (
 import Test.Hspec
 import LogicTasks.Util (checkCnfConf)
 import Util.VerifyConfig
+import Control.OutputCapable.Blocks (Language(German))
 
 -- Weight 0.34
 task06 :: FillConfig
@@ -47,5 +48,5 @@ task20 = FillConfig
 
 spec :: Spec
 spec = do
-  describe "task06" $ verifyConfig (cnfConf task06) checkCnfConf
-  describe "task20" $ verifyConfig (cnfConf task20) checkCnfConf
+  describe "task06" $ verifyConfig German (cnfConf task06) checkCnfConf
+  describe "task20" $ verifyConfig German (cnfConf task20) checkCnfConf

--- a/examples/src/Semantics/TruthTables/FindMistakes/Config.hs
+++ b/examples/src/Semantics/TruthTables/FindMistakes/Config.hs
@@ -5,7 +5,7 @@ import LogicTasks.Config (
   DecideConfig(..),
   CnfConfig(..),
   )
-import Control.OutputCapable.Blocks (english, german, translations)
+import Control.OutputCapable.Blocks (english, german, translations, Language (German))
 import Test.Hspec
 import LogicTasks.Util (checkCnfConf)
 import Util.VerifyConfig
@@ -48,5 +48,5 @@ task11 = DecideConfig
 
 spec :: Spec
 spec = do
-  describe "task09" $ verifyConfig (cnfConf task09) checkCnfConf
-  describe "task11" $ verifyConfig (cnfConf task11) checkCnfConf
+  describe "task09" $ verifyConfig German (cnfConf task09) checkCnfConf
+  describe "task11" $ verifyConfig German (cnfConf task11) checkCnfConf

--- a/examples/src/Semantics/TruthTables/MaxTerm/Config.hs
+++ b/examples/src/Semantics/TruthTables/MaxTerm/Config.hs
@@ -8,6 +8,7 @@ import LogicTasks.Config (
 import Test.Hspec
 import LogicTasks.Util (checkCnfConf)
 import Util.VerifyConfig
+import Control.OutputCapable.Blocks (Language(German))
 
 -- Weight 0.33
 -- Type: Max
@@ -47,5 +48,5 @@ unused02 = MinMaxConfig
 
 spec :: Spec
 spec = do
-  describe "unused01" $ verifyConfig (cnfConf unused01) checkCnfConf
-  describe "unused02" $ verifyConfig (cnfConf unused02) checkCnfConf
+  describe "unused01" $ verifyConfig German (cnfConf unused01) checkCnfConf
+  describe "unused02" $ verifyConfig German (cnfConf unused02) checkCnfConf

--- a/examples/src/Semantics/TruthTables/MinTerm/Config.hs
+++ b/examples/src/Semantics/TruthTables/MinTerm/Config.hs
@@ -8,6 +8,7 @@ import LogicTasks.Config (
 import Test.Hspec
 import LogicTasks.Util (checkCnfConf)
 import Util.VerifyConfig
+import Control.OutputCapable.Blocks (Language(German))
 
 -- Weight 0.2
 -- Type: Min
@@ -29,4 +30,4 @@ unused03 = MinMaxConfig
 
 spec :: Spec
 spec = do
-  describe "unused03" $ verifyConfig (cnfConf unused03) checkCnfConf
+  describe "unused03" $ verifyConfig German (cnfConf unused03) checkCnfConf

--- a/examples/src/Syntax/ComposeFormula/Config.hs
+++ b/examples/src/Syntax/ComposeFormula/Config.hs
@@ -9,6 +9,7 @@ import Tasks.SynTree.Config (
 
 import Test.Hspec
 import Util.VerifyConfig
+import Control.OutputCapable.Blocks (Language(German))
 
 
 small :: ComposeFormulaConfig
@@ -51,5 +52,5 @@ medium = ComposeFormulaConfig
 
 spec :: Spec
 spec = do
-  describe "small" $ verifyConfig small checkComposeFormulaConfig
-  describe "medium" $ verifyConfig medium checkComposeFormulaConfig
+  describe "small" $ verifyConfig German small checkComposeFormulaConfig
+  describe "medium" $ verifyConfig German medium checkComposeFormulaConfig

--- a/examples/src/Syntax/DecomposeFormula/Config.hs
+++ b/examples/src/Syntax/DecomposeFormula/Config.hs
@@ -7,6 +7,7 @@ import Tasks.SynTree.Config (
   )
 import Test.Hspec
 import Util.VerifyConfig
+import Control.OutputCapable.Blocks (Language(German))
 
 small :: DecomposeFormulaConfig
 small = DecomposeFormulaConfig
@@ -46,5 +47,5 @@ medium = DecomposeFormulaConfig
 
 spec :: Spec
 spec = do
-  describe "small" $ verifyConfig small checkDecomposeFormulaConfig
-  describe "medium" $ verifyConfig medium checkDecomposeFormulaConfig
+  describe "small" $ verifyConfig German small checkDecomposeFormulaConfig
+  describe "medium" $ verifyConfig German medium checkDecomposeFormulaConfig

--- a/examples/src/Syntax/InvalidCnfs/Config.hs
+++ b/examples/src/Syntax/InvalidCnfs/Config.hs
@@ -9,6 +9,7 @@ import Tasks.LegalCNF.Config (
   )
 import Test.Hspec
 import Util.VerifyConfig
+import Control.OutputCapable.Blocks (Language(German))
 
 -- Weight 0.33
 task07 :: LegalCNFConfig
@@ -54,5 +55,5 @@ task18 = LegalCNFConfig
 
 spec :: Spec
 spec = do
-  describe "task07" $ verifyConfig task07 checkLegalCNFConfig
-  describe "task18" $ verifyConfig task18 checkLegalCNFConfig
+  describe "task07" $ verifyConfig German task07 checkLegalCNFConfig
+  describe "task18" $ verifyConfig German task18 checkLegalCNFConfig

--- a/examples/src/Syntax/InvalidFormulas/Config.hs
+++ b/examples/src/Syntax/InvalidFormulas/Config.hs
@@ -8,6 +8,7 @@ import Tasks.SynTree.Config (
   )
 import Test.Hspec
 import Util.VerifyConfig
+import Control.OutputCapable.Blocks (Language(German))
 
 -- Weight 0.33
 task01 :: LegalPropositionConfig
@@ -53,5 +54,5 @@ task17 = LegalPropositionConfig
 
 spec :: Spec
 spec = do
-  describe "task01" $ verifyConfig task01 checkLegalPropositionConfig
-  describe "task17" $ verifyConfig task17 checkLegalPropositionConfig
+  describe "task01" $ verifyConfig German task01 checkLegalPropositionConfig
+  describe "task17" $ verifyConfig German task17 checkLegalPropositionConfig

--- a/examples/src/Syntax/RemoveBrackets/Config.hs
+++ b/examples/src/Syntax/RemoveBrackets/Config.hs
@@ -6,7 +6,7 @@ import Tasks.SuperfluousBrackets.Config (
 import Tasks.SynTree.Config (
   SynTreeConfig(..),
   )
-import Control.OutputCapable.Blocks (english, german, translations)
+import Control.OutputCapable.Blocks (english, german, translations, Language (German))
 import Test.Hspec
 import Util.VerifyConfig
 
@@ -55,5 +55,5 @@ task05 = SuperfluousBracketsConfig
 
 spec :: Spec
 spec = do
-  describe "task02" $ verifyConfig task02 checkSuperfluousBracketsConfig
-  describe "task05" $ verifyConfig task05 checkSuperfluousBracketsConfig
+  describe "task02" $ verifyConfig German task02 checkSuperfluousBracketsConfig
+  describe "task05" $ verifyConfig German task05 checkSuperfluousBracketsConfig

--- a/examples/src/Syntax/Subformulas/Config.hs
+++ b/examples/src/Syntax/Subformulas/Config.hs
@@ -8,6 +8,7 @@ import Tasks.SynTree.Config (
   SynTreeConfig(..),
   )
 import Util.VerifyConfig
+import Control.OutputCapable.Blocks (Language(German))
 
 medium :: SubTreeConfig
 medium = SubTreeConfig
@@ -30,4 +31,4 @@ medium = SubTreeConfig
 
 spec :: Spec
 spec = do
-  describe "medium" $ verifyConfig medium checkSubTreeConfig
+  describe "medium" $ verifyConfig German medium checkSubTreeConfig

--- a/examples/src/Syntax/TreeToFormula/Config.hs
+++ b/examples/src/Syntax/TreeToFormula/Config.hs
@@ -9,6 +9,7 @@ import Tasks.TreeToFormula.Config (
   TreeToFormulaConfig(..),checkTreeToFormulaConfig,
   )
 import Util.VerifyConfig
+import Control.OutputCapable.Blocks (Language(German))
 
 -- Weight 0.34
 task03 :: TreeToFormulaConfig
@@ -54,5 +55,5 @@ task10 = task04
 
 spec :: Spec
 spec = do
-  describe "task03" $ verifyConfig task03 checkTreeToFormulaConfig
-  describe "task04" $ verifyConfig task04 checkTreeToFormulaConfig
+  describe "task03" $ verifyConfig German task03 checkTreeToFormulaConfig
+  describe "task04" $ verifyConfig German task04 checkTreeToFormulaConfig

--- a/examples/src/Util/VerifyConfig.hs
+++ b/examples/src/Util/VerifyConfig.hs
@@ -4,13 +4,13 @@
 {-# LANGUAGE TypeApplications #-}
 module Util.VerifyConfig where
 
-import Control.OutputCapable.Blocks (LangM, OutputCapable)
+import Control.OutputCapable.Blocks (LangM, OutputCapable, Language)
 import Test.Hspec
-import LogicTasks.Debug (checkConfigWith)
 import Type.Reflection
+import Control.OutputCapable.Blocks.Debug (checkConfigWith)
 
-verifyConfig :: a -> (forall m. OutputCapable m => a -> LangM m) -> Spec
-verifyConfig config checker = itIsValid $ checkConfigWith config checker `shouldReturn` True
+verifyConfig :: Language -> a -> (forall m. OutputCapable m => a -> LangM m) -> Spec
+verifyConfig lang config checker = itIsValid $ checkConfigWith lang config checker `shouldReturn` True
 
 noChecker :: forall a. Typeable a => a -> Spec
 noChecker _ = itIsValid $ pendingWith $ "no checker for " ++ show (typeRep @a)

--- a/logic-tasks.cabal
+++ b/logic-tasks.cabal
@@ -69,6 +69,7 @@ library
       Formula.Resolution
   other-modules:
       Auxiliary
+      Formula.Parsing.Delayed.Internal
       Formula.Printing
       Formula.Table
       Formula.Util

--- a/src/Formula/Parsing/Delayed.hs
+++ b/src/Formula/Parsing/Delayed.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 module Formula.Parsing.Delayed (Delayed, delayed, withDelayed, parseDelayedAndThen, complainAboutMissingParenthesesIfNotFailingOn) where
 
-import Text.Parsec (ParseError, parse, anyChar, many)
+import Text.Parsec (ParseError, parse)
 import Text.Parsec.String (Parser)
 import Formula.Parsing (Parse(..))
 import ParsingHelpers (fully)
@@ -11,18 +11,7 @@ import Control.Monad.State (State)
 import Data.Map (Map)
 
 import LogicTasks.Helpers (reject)
-import Text.PrettyPrint.Leijen.Text (Pretty(..))
-
-newtype Delayed a = Delayed String
-
-instance Show a => Show (Delayed a) where
-  show (Delayed a) = show a
-
-instance Parse (Delayed a) where
-  parser = delayed <$> fully (many anyChar)
-
-instance Pretty a => Pretty (Delayed a) where
-  pretty (Delayed a) = pretty a
+import Formula.Parsing.Delayed.Internal (Delayed(..))
 
 delayed :: String -> Delayed a
 delayed = Delayed

--- a/src/Formula/Parsing/Delayed.hs
+++ b/src/Formula/Parsing/Delayed.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 module Formula.Parsing.Delayed (Delayed, delayed, withDelayed, parseDelayedAndThen, complainAboutMissingParenthesesIfNotFailingOn) where
 
-import Text.Parsec (ParseError, parse)
+import Text.Parsec (ParseError, parse, anyChar, many)
 import Text.Parsec.String (Parser)
 import Formula.Parsing (Parse(..))
 import ParsingHelpers (fully)
@@ -11,8 +11,18 @@ import Control.Monad.State (State)
 import Data.Map (Map)
 
 import LogicTasks.Helpers (reject)
+import Text.PrettyPrint.Leijen.Text (Pretty(..))
 
 newtype Delayed a = Delayed String
+
+instance Show a => Show (Delayed a) where
+  show (Delayed a) = show a
+
+instance Parse (Delayed a) where
+  parser = delayed <$> fully (many anyChar)
+
+instance Pretty a => Pretty (Delayed a) where
+  pretty (Delayed a) = pretty a
 
 delayed :: String -> Delayed a
 delayed = Delayed

--- a/src/Formula/Parsing/Delayed/Internal.hs
+++ b/src/Formula/Parsing/Delayed/Internal.hs
@@ -1,0 +1,3 @@
+module Formula.Parsing.Delayed.Internal (Delayed(..)) where
+
+newtype Delayed a = Delayed String

--- a/src/LogicTasks/Debug.hs
+++ b/src/LogicTasks/Debug.hs
@@ -18,11 +18,6 @@ import Formula.Parsing.Delayed (delayed, Delayed)
 import ParsingHelpers (fully)
 import Control.OutputCapable.Blocks.Debug (run)
 
-showDescription :: (m ~ GenericReportT Language (IO ()) IO) => Gen inst -> (inst -> LangM m) -> IO (Maybe ())
-showDescription gen f = do
-  inst <- generate gen
-  run German (f inst)
-
 testTaskShow ::
   (m ~ GenericReportT Language (IO ()) IO) =>
   ((String, a) -> String) ->

--- a/src/LogicTasks/Debug.hs
+++ b/src/LogicTasks/Debug.hs
@@ -19,7 +19,6 @@ import Control.OutputCapable.Blocks.Debug (testTask, Display)
 import Formula.Parsing.Delayed (delayed)
 import Formula.Parsing.Delayed.Internal (Delayed(..))
 import Formula.Parsing (Parse(..))
-import Text.PrettyPrint.Leijen.Text (Pretty(..))
 import ParsingHelpers (fully)
 
 instance Show (Delayed a) where

--- a/src/LogicTasks/Debug.hs
+++ b/src/LogicTasks/Debug.hs
@@ -17,11 +17,12 @@ import Data.List (partition)
 import Data.List.Extra (nubSort)
 import Formula.Parsing.Delayed (delayed, Delayed)
 import ParsingHelpers (fully)
+import Control.OutputCapable.Blocks.Debug (run)
 
 showDescription :: (m ~ GenericReportT Language (IO ()) IO) => Gen inst -> (inst -> LangM m) -> IO (Maybe ())
 showDescription gen f = do
   inst <- generate gen
-  run (f inst)
+  run German (f inst)
 
 testTaskShow ::
   (m ~ GenericReportT Language (IO ()) IO) =>
@@ -34,7 +35,7 @@ testTaskShow ::
   IO ()
 testTaskShow sho gen f partial full p = do
   inst <- generate gen
-  desc <- run (f inst)
+  desc <- run German (f inst)
   print desc
   str <- getLine
   case parse p "input" str of
@@ -43,10 +44,10 @@ testTaskShow sho gen f partial full p = do
       putStrLn "---- Input ----"
       putStrLn $ sho (str,value)
       putStrLn "---- Partial ----"
-      partialRes <- run (partial inst value)
+      partialRes <- run German (partial inst value)
       print partialRes
       putStrLn "---- Complete ----"
-      completeRes <- run (full inst value)
+      completeRes <- run German (full inst value)
       print completeRes
 
 testTask ::
@@ -69,13 +70,8 @@ testTaskDelayed ::
 testTaskDelayed gen f partial full = testTaskShow fst gen f partial full (delayed <$> fully (many anyChar))
 
 checkConfigWith :: (m ~ GenericReportT Language (IO ()) IO) => config -> (config -> LangM m) -> IO Bool
-checkConfigWith conf check = isJust <$> run (check conf)
+checkConfigWith conf check = isJust <$> run German (check conf)
 
-run :: (m ~ GenericReportT Language (IO ()) IO) => LangM m -> IO (Maybe ())
-run thing = do
-  (r,sayThing) <- runLangMReport (pure ()) (>>) thing
-  sayThing German
-  pure r
 
 analyseCnfGenerator :: Gen Cnf -> IO ()
 analyseCnfGenerator gen = quickCheckWith stdArgs{maxSuccess=1000} $ forAll gen $ \cnf ->

--- a/src/LogicTasks/Debug.hs
+++ b/src/LogicTasks/Debug.hs
@@ -9,7 +9,6 @@ import Control.OutputCapable.Blocks.Generic
 import Control.OutputCapable.Blocks
 import Text.Parsec
 import Text.Parsec.String (Parser)
-import Data.Maybe (isJust)
 import Formula.Types (Cnf(..), Clause(..), Literal(..), Formula(..))
 import Formula.Util (isPositive)
 import Data.Set (size, toList)
@@ -68,9 +67,6 @@ testTaskDelayed ::
   (inst -> Delayed a -> LangM m) ->
   IO ()
 testTaskDelayed gen f partial full = testTaskShow fst gen f partial full (delayed <$> fully (many anyChar))
-
-checkConfigWith :: (m ~ GenericReportT Language (IO ()) IO) => config -> (config -> LangM m) -> IO Bool
-checkConfigWith conf check = isJust <$> run German (check conf)
 
 
 analyseCnfGenerator :: Gen Cnf -> IO ()

--- a/src/LogicTasks/Debug.hs
+++ b/src/LogicTasks/Debug.hs
@@ -28,9 +28,6 @@ instance Show (Delayed a) where
 instance Parse (Delayed a) where
   parser = delayed <$> fully (many anyChar)
 
-instance Pretty (Delayed a) where
-  pretty (Delayed a) = pretty a
-
 testModule ::
   (m ~ GenericReportT Language (IO ()) IO, Show a) =>
   Maybe (Display a) ->

--- a/test/FormulaSpec.hs
+++ b/test/FormulaSpec.hs
@@ -8,7 +8,6 @@ import Test.QuickCheck
 import LogicTasks.Formula
 import LogicTasks.Config
 import LogicTasks.Util
-import LogicTasks.Debug (checkConfigWith)
 import Formula.Types (lengthBound)
 
 validBoundsClause :: Gen ((Int,Int),[Char])

--- a/test/FormulaSpec.hs
+++ b/test/FormulaSpec.hs
@@ -9,6 +9,8 @@ import LogicTasks.Formula
 import LogicTasks.Config
 import LogicTasks.Util
 import Formula.Types (lengthBound)
+import Control.OutputCapable.Blocks (Language(German))
+import Control.OutputCapable.Blocks.Debug (checkConfigWith)
 
 validBoundsClause :: Gen ((Int,Int),[Char])
 validBoundsClause = do
@@ -37,12 +39,12 @@ spec = do
   describe "genValidBoundsClause" $
     it "should generate valid bounds" $
       forAll validBoundsClause $ \((l,u),cs) ->
-        ioProperty $ BaseConfig l u cs `checkConfigWith` checkBaseConf
+        ioProperty $ checkConfigWith German (BaseConfig l u cs) checkBaseConf
 
   describe "genValidBoundsCnf" $
     it "should generate valid bounds" $
       withMaxSuccess 1000 $ forAll validBoundsCnf $ \((l1,u1),(l2,u2),cs) ->
-        ioProperty $ CnfConfig (BaseConfig l2 u2 cs) l1 u1 `checkConfigWith` checkCnfConf
+        ioProperty $ checkConfigWith German (CnfConfig (BaseConfig l2 u2 cs) l1 u1) checkCnfConf
 
   describe "genLiteral" $ do
     it "should throw an error when called with the empty list" $

--- a/test/LegalCNFSpec.hs
+++ b/test/LegalCNFSpec.hs
@@ -21,7 +21,6 @@ import Tasks.LegalCNF.GenerateLegal (genCnf)
 import Tasks.LegalCNF.Quiz (generateLegalCNFInst)
 
 import FormulaSpec (validBoundsCnf)
-import LogicTasks.Debug (checkConfigWith)
 
 validBoundsLegalCNF :: Gen LegalCNFConfig
 validBoundsLegalCNF = do

--- a/test/LegalCNFSpec.hs
+++ b/test/LegalCNFSpec.hs
@@ -19,6 +19,8 @@ import Tasks.LegalCNF.Config (LegalCNFConfig(..), LegalCNFInst(..), checkLegalCN
 import Tasks.LegalCNF.GenerateIllegal (genIllegalSynTree, )
 import Tasks.LegalCNF.GenerateLegal (genCnf)
 import Tasks.LegalCNF.Quiz (generateLegalCNFInst)
+import Control.OutputCapable.Blocks (Language(German))
+import Control.OutputCapable.Blocks.Debug(checkConfigWith)
 
 import FormulaSpec (validBoundsCnf)
 
@@ -106,12 +108,12 @@ spec = do
     describe "validBoundsLegalCNF" $
         it "produces a valid config" $
           withMaxSuccess 1000 $ forAll validBoundsLegalCNF $ \conf ->
-            ioProperty $ conf `checkConfigWith` checkLegalCNFConfig
+            ioProperty $ checkConfigWith German conf checkLegalCNFConfig
 
     describe "invalidBoundsLegalCNF" $
         xit "produces a valid config" $
           forAll invalidBoundsLegalCNF $ \conf ->
-            ioProperty (not <$> conf `checkConfigWith` checkLegalCNFConfig)
+            ioProperty (not <$> checkConfigWith German conf checkLegalCNFConfig)
 
     describe "genIllegalSynTree" $
         it "the syntax Tree are not CNF syntax tree" $


### PR DESCRIPTION
Einige lokale Definitionen in `LogicTasks.Debug` konnten komplett durch `output-blocks` Funktionen ersetzt werden. Die neue `testModule` Funktion nutzt `Control.OutputCapable.Blocks.Debug.testTask`, vereinfacht aber den Funktionsaufruf. 

Des Weiteren habe ich die `README.md` mit einer Anleitung zum Testen ergänzt.

#130 