### PR TITLE
Add missing `Parse` instance for debug

### DIFF
--- a/src/LogicTasks/Debug.hs
+++ b/src/LogicTasks/Debug.hs
@@ -20,9 +20,12 @@ import Control.OutputCapable.Blocks.Debug (testTask, Display)
 import Formula.Parsing.Delayed (delayed)
 import Formula.Parsing.Delayed.Internal (Delayed(..))
 import Formula.Parsing (Parse(..))
-import ParsingHelpers (fully)
+import ParsingHelpers (fully, lexeme)
 
 deriving instance Show (Delayed a)
+
+instance Parse Int where
+  parser = read <$> lexeme (many1 digit) <?> "Int"
 
 instance Parse (Delayed a) where
   parser = delayed <$> fully (many anyChar)


### PR DESCRIPTION
There is currently no `Parse` instance for `Int`. This leads to type errors when trying to debug the `Decide` task, for example. 

It would also be possible to change the "solution type" from `[Int]` to `[Number]`.