### PR TITLE
Formelausgabe bei `IllegalFormulas` anpassen

### DIFF
--- a/src/Tasks/LegalProposition/Config.hs
+++ b/src/Tasks/LegalProposition/Config.hs
@@ -12,7 +12,6 @@ module Tasks.LegalProposition.Config (
 
 
 import Control.OutputCapable.Blocks (LangM, Language, OutputCapable, english, german)
-import Data.Set (Set)
 import GHC.Generics (Generic)
 import Data.Map (Map)
 
@@ -84,9 +83,7 @@ checkAdditionalConfig config@LegalPropositionConfig {syntaxTreeConfig = SynTreeC
 data LegalPropositionInst =
     LegalPropositionInst
     {
-      serialsOfWrong :: Set Int
-    , pseudoFormulas :: [String]
+      pseudoFormulas :: [(String, Maybe (SynTree BinOp Char))]
     , showSolution :: Bool
-    , correctTrees :: [SynTree BinOp Char]
     , addText :: Maybe (Map Language String)
     } deriving (Show,Generic)

--- a/src/Tasks/LegalProposition/Quiz.hs
+++ b/src/Tasks/LegalProposition/Quiz.hs
@@ -6,7 +6,6 @@ module Tasks.LegalProposition.Quiz (
 
 
 import Data.Char (isLetter)
-import Data.Set (fromList)
 import Test.QuickCheck (Gen, choose, suchThat, vectorOf)
 
 import Auxiliary (listNoDuplicate)
@@ -34,9 +33,7 @@ generateLegalPropositionInst LegalPropositionConfig  {..} = do
       `suchThat` (listNoDuplicate . (++ serialsOfWrong))
     pseudoFormulas <- genPseudoList serialsOfWrong serialsOfBracket treeList `suchThat` noSimilarFormulas
     return $ LegalPropositionInst
-        { serialsOfWrong = fromList serialsOfWrong
-        , pseudoFormulas = pseudoFormulas
-        , correctTrees = [ tree | (index, tree) <- zip [1..] treeList, index `notElem` serialsOfWrong ]
+        { pseudoFormulas = zipWith (\i t-> (pseudoFormulas !! (i - 1), if i `elem` serialsOfWrong then Nothing else Just t)) [1..] treeList
         , showSolution = printSolution
         , addText = extraText
         }

--- a/test/LegalPropositionSpec.hs
+++ b/test/LegalPropositionSpec.hs
@@ -2,7 +2,6 @@
 
 module LegalPropositionSpec (spec) where
 
-import Data.Set (toList)
 import Data.Either (isLeft, isRight)
 import Data.List ((\\))
 import Data.Char (isLetter)
@@ -24,7 +23,7 @@ import SynTreeSpec (validBoundsSynTree)
 import Trees.Print (display)
 import TestHelpers (deleteBrackets, deleteSpaces)
 import Control.OutputCapable.Blocks (LangM)
-import Data.Maybe (isJust)
+import Data.Maybe (isJust,isNothing)
 import Control.Monad.Identity (Identity(runIdentity))
 import Control.OutputCapable.Blocks.Generic (evalLangM)
 import Tasks.LegalProposition.Helpers (formulaAmount)
@@ -89,10 +88,12 @@ spec = do
         it "the generateLegalPropositionInst should generate expected illegal number" $
             within timeout $ forAll validBoundsLegalProposition $ \config ->
                 forAll (generateLegalPropositionInst config) $ \LegalPropositionInst{..} ->
-                  all (\x -> isLeft (formulaParse (pseudoFormulas !! (x - 1)))) (toList serialsOfWrong)
+                  let serialsOfWrong = map fst $ filter (\(_,(_,mt)) -> isNothing mt) (zip [1..] pseudoFormulas) in
+                    all (\x -> isLeft (formulaParse (fst (pseudoFormulas !! (x - 1))))) serialsOfWrong
         it "the generateLegalPropositionInst should generate expected legal number" $
             within timeout $ forAll validBoundsLegalProposition $ \config@LegalPropositionConfig{..} ->
                 forAll (generateLegalPropositionInst config) $ \LegalPropositionInst{..} ->
-                  all
-                  (\x -> isRight (formulaParse (pseudoFormulas !! (x - 1))))
-                  ([1 .. fromIntegral formulas] \\ toList serialsOfWrong)
+                  let serialsOfWrong = map fst $ filter (\(_,(_,mt)) -> isNothing mt) (zip [1..] pseudoFormulas) in
+                    all
+                    (\x -> isRight (formulaParse (fst (pseudoFormulas !! (x - 1)))))
+                    ([1 .. fromIntegral formulas] \\ serialsOfWrong)


### PR DESCRIPTION
Behebt #133

Im Feedback wird jetzt jeweils die Pseudoformel (also u.a. mit redundanter Klammerung) mit ihrer entsprechenden Nummerierung angezeigt. 