### PR TITLE
Anpassen von Test-Konfigurationen

### DIFF
--- a/test/PickSpec.hs
+++ b/test/PickSpec.hs
@@ -28,7 +28,7 @@ validBoundsPick = do
     _ -> FormulaArbitrary <$> validBoundsSynTree `suchThat` \SynTreeConfig{..} ->
             amountOfOptions <= 4*2^ length availableAtoms &&
             minAmountOfUniqueAtoms == fromIntegral (length availableAtoms) &&
-            maxNodes <= 100
+            maxNodes <= 40
 
   percentTrueEntries' <- (do
     percentTrueEntriesLow' <- choose (1, 90)


### PR DESCRIPTION
Bzgl. #168 

Eine Beschränkung auf Syntaxbäume mit maximal 40 Knoten (bei `Pick`) reduziert die Dauer der Test erheblich (lokal zuvor 380s; nun 90s).

