### PR TITLE
Lösungen in den Instanzen speichern

### DIFF
--- a/src/Config.hs
+++ b/src/Config.hs
@@ -115,6 +115,7 @@ dMinInst =  MinInst
 data FillInst = FillInst {
                  formula :: FormulaInst
                , missing :: ![Int]
+               , missingValues :: [Bool]
                , showSolution :: Bool
                , addText :: Maybe (Map Language String)
                }
@@ -124,6 +125,7 @@ dFillInst :: FillInst
 dFillInst =  FillInst
           { formula = InstCnf $ mkCnf [mkClause [Literal 'A', Not 'B']]
           , missing = [1,4]
+          , missingValues = [True, True]
           , showSolution = False
           , addText = Nothing
           }

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -153,6 +153,7 @@ dDecideInst =  DecideInst
 data StepInst = StepInst {
                  clause1 :: !Clause
                , clause2 :: !Clause
+               , solution :: (Literal, Clause)
                , usesSetNotation :: Bool
                , showSolution :: Bool
                , addText :: Maybe (Map Language String)
@@ -163,6 +164,7 @@ dStepInst :: StepInst
 dStepInst =  StepInst
           { clause1 = mkClause [Not 'A', Not 'C', Literal 'B']
           , clause2 = mkClause [Literal 'A', Not 'C']
+          , solution = (Literal 'A', mkClause [Not 'C', Literal 'B'])
           , usesSetNotation = False
           , showSolution = False
           , addText = Nothing

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -214,6 +214,7 @@ dResInst = let
 data PrologInst = PrologInst {
                  literals1 :: !PrologClause
                , literals2 :: !PrologClause
+               , solution :: (PrologLiteral, PrologClause)
                , showSolution :: Bool
                , addText :: Maybe (Map Language String)
                }
@@ -224,6 +225,7 @@ dPrologInst :: PrologInst
 dPrologInst =  PrologInst
           { literals1 = mkPrologClause [PrologLiteral True "pred" ["fact"]]
           , literals2 = mkPrologClause [PrologLiteral False "pred" ["fact"]]
+          , solution = (PrologLiteral True "pred" ["fact"], mkPrologClause [])
           , showSolution = False
           , addText = Nothing
           }

--- a/src/LogicTasks/Semantics/Prolog.hs
+++ b/src/LogicTasks/Semantics/Prolog.hs
@@ -198,7 +198,7 @@ completeGrade' PrologInst{..} sol =
     transSol2 = transformProlog (snd sol) mapping
     resolveResult = resolve clause1 clause2 transSol1
     displaySolution = when showSolution $ do
-          example ("(" ++ show (fst solution) ++ ", " ++ show (snd solution) ++ ")") $ do
+          example (show solution) $ do
             english "A possible solution for this task is:"
             german "Eine mögliche Lösung für die Aufgabe ist:"
           pure ()

--- a/src/LogicTasks/Semantics/Prolog.hs
+++ b/src/LogicTasks/Semantics/Prolog.hs
@@ -36,8 +36,16 @@ genPrologInst PrologConfig{..} = (do
     let
       termAddedClause1 = mkPrologClause $ map remap (resolveLit : literals1)
       termAddedClause2 = mkPrologClause $ map remap (opposite resolveLit : literals clause)
-    pure $ PrologInst termAddedClause1 termAddedClause2 printSolution extraText)
-  `suchThat` \(PrologInst clause1 clause2 _ _) -> hasTheClauseShape firstClauseShape clause1 && hasTheClauseShape secondClauseShape clause2
+      resultClause = literals1 ++ filter (`notElem` literals1) (literals clause)
+
+    pure $ PrologInst {
+      literals1 = termAddedClause1
+    , literals2 = termAddedClause2
+    , solution = (remap resolveLit, mkPrologClause (map remap resultClause))
+    , showSolution = printSolution
+    , addText = extraText
+    })
+  `suchThat` \(PrologInst clause1 clause2 _ _ _) -> hasTheClauseShape firstClauseShape clause1 && hasTheClauseShape secondClauseShape clause2
   where
     mapping = zip usedPredicates ['A'..'Z']
     usedLiterals = map snd mapping
@@ -190,7 +198,7 @@ completeGrade' PrologInst{..} sol =
     transSol2 = transformProlog (snd sol) mapping
     resolveResult = resolve clause1 clause2 transSol1
     displaySolution = when showSolution $ do
-          example ("(" ++ show transSol1 ++ ", " ++ show (fromJust resolveResult) ++ ")") $ do
+          example ("(" ++ show (fst solution) ++ ", " ++ show (snd solution) ++ ")") $ do
             english "A possible solution for this task is:"
             german "Eine mögliche Lösung für die Aufgabe ist:"
           pure ()

--- a/src/LogicTasks/Semantics/Step.hs
+++ b/src/LogicTasks/Semantics/Step.hs
@@ -196,7 +196,7 @@ completeGrade' StepInst{..} sol =
             pure ()
   where
     mSol = fromJust $ step sol
-    displaySolution = when showSolution $ example ("(" ++ show (fst solution) ++ ", " ++ show (snd solution) ++ ")") $ do
+    displaySolution = when showSolution $ example (show solution) $ do
           english "A possible solution for this task is:"
           german "Eine mögliche Lösung für die Aufgabe ist:"
 

--- a/src/LogicTasks/Semantics/Step.hs
+++ b/src/LogicTasks/Semantics/Step.hs
@@ -20,7 +20,7 @@ import Test.QuickCheck (Gen, elements)
 
 import Config (StepAnswer(..), StepConfig(..), StepInst(..), BaseConfig(..))
 import Formula.Util (isEmptyClause, mkClause)
-import Formula.Types (Clause(Clause, literalSet), Literal(..), genClause, literals, opposite)
+import Formula.Types (Clause, Literal(..), genClause, literals, opposite)
 import Formula.Resolution (resolvable, resolve)
 import LogicTasks.Helpers (example, extra, keyHeading, negationKey, orKey)
 import Util (checkBaseConf, prevent, preventWithHint, tryGen)
@@ -38,9 +38,11 @@ genStepInst StepConfig{ baseConf = BaseConfig{..}, ..} = do
     let
       litAddedClause1 = mkClause $ resolveLit : lits1
       litAddedClause2 = mkClause $ opposite resolveLit : literals clause2
+      resolutionClause = mkClause $ lits1 ++ filter (`notElem` lits1) (literals clause2)
     pure $ StepInst {
       clause1 = litAddedClause1,
       clause2 = litAddedClause2,
+      solution = (resolveLit, resolutionClause),
       usesSetNotation = useSetNotation,
       showSolution = printSolution,
       addText = extraText
@@ -194,9 +196,7 @@ completeGrade' StepInst{..} sol =
             pure ()
   where
     mSol = fromJust $ step sol
-    correctLiteral = head [ x | x <- toList (literalSet clause1), opposite x `elem` toList (literalSet clause2) ]
-    correctResolvent = (literalSet clause1 `union` literalSet clause2) `difference` fromList [correctLiteral, opposite correctLiteral]
-    displaySolution = when showSolution $ example ("(" ++ show correctLiteral ++ ", " ++ show (Clause correctResolvent) ++ ")") $ do
+    displaySolution = when showSolution $ example ("(" ++ show (fst solution) ++ ", " ++ show (snd solution) ++ ")") $ do
           english "A possible solution for this task is:"
           german "Eine mögliche Lösung für die Aufgabe ist:"
 

--- a/test/FillSpec.hs
+++ b/test/FillSpec.hs
@@ -7,12 +7,12 @@ import Test.Hspec
 import Test.QuickCheck (forAll, Gen, choose, elements, suchThat, sublistOf)
 import Control.OutputCapable.Blocks (LangM)
 import Config (dFillConf, FillConfig (..), FillInst (..), FormulaConfig(..), BaseConfig(..), dBaseConf, CnfConfig(..), dCnfConf)
-import LogicTasks.Semantics.Fill (verifyQuiz, genFillInst, verifyStatic)
+import LogicTasks.Semantics.Fill (verifyQuiz, genFillInst, verifyStatic, partialGrade, completeGrade)
 import Data.Maybe (isJust, fromMaybe)
 import Control.Monad.Identity (Identity(runIdentity))
 import Control.OutputCapable.Blocks.Generic (evalLangM)
 import SynTreeSpec (validBoundsSynTree)
-import Formula.Types (Table(getEntries), getTable, lengthBound)
+import Formula.Types (Table(getEntries), getTable, lengthBound, TruthValue (TruthValue))
 import Tasks.SynTree.Config (SynTreeConfig(..))
 import Util (withRatio, checkBaseConf, checkCnfConf)
 -- jscpd:ignore-end
@@ -101,4 +101,9 @@ spec = do
       forAll validBoundsFill $ \fillConfig -> do
         forAll (genFillInst fillConfig) $ \fillInst ->
           isJust $ runIdentity $ evalLangM (verifyStatic fillInst :: LangM Maybe)
+    it "the generated solution should pass grading" $
+      forAll validBoundsFill $ \fillConfig -> do
+        forAll (genFillInst fillConfig) $ \fillInst ->
+          isJust (runIdentity (evalLangM (partialGrade fillInst (map TruthValue (missingValues fillInst))  :: LangM Maybe))) &&
+          isJust (runIdentity (evalLangM (completeGrade fillInst (map TruthValue (missingValues fillInst))  :: LangM Maybe)))
 


### PR DESCRIPTION
Bei der `Prolog` Aufgabe ist mir aufgefallen, dass ursprünglich beim Anzeigen der Lösung nicht direkt die Prolog-Prädikate (z. B. `f(a)`), sondern "normale" Literale (z. B.: `A`) verwendet werden. Das könnte für den Nutzer verwirrend sein, da in der Aufgabenstellung immer nur Prolog-Prädikate verwendet werden. Wenn dann als Lösung z. B. `(A, B oder nicht C)` angezeigt wird, muss man erstmal noch die Prolog-Prädikate den "normalen" Literalen zuordnen.


Die neue Implementierung für die Lösungsanzeige Prolog-Prädikate. Falls das nicht gewünscht ist, kann ich das nochmal anpassen.

#152 