### PR TITLE
Teilpunkte vergeben bei `IllegalFormulas` und `IllegalCnfs`

### DIFF
--- a/src/LogicTasks/Debug.hs
+++ b/src/LogicTasks/Debug.hs
@@ -35,13 +35,13 @@ instance Parse (Delayed a) where
   parser = delayed <$> fully (many anyChar)
 
 testModule ::
-  (m ~ GenericReportT Language (IO ()) IO, Show a) =>
+  (m ~ GenericReportT Language (IO ()) IO, Show a, Show c) =>
   Maybe (Display a) ->
   Language ->
   Gen inst ->
   (inst -> LangM m) ->
   (inst -> a -> LangM m) ->
-  (inst -> a -> LangM m) ->
+  (inst -> a -> LangM' m c) ->
   Parser a ->
   IO ()
 testModule prettyCfg lang gen desc partial complete p =

--- a/src/LogicTasks/Syntax/IllegalCnfs.hs
+++ b/src/LogicTasks/Syntax/IllegalCnfs.hs
@@ -19,7 +19,7 @@ import Data.Set (toList)
 import Data.Map as Map (fromAscList)
 import LogicTasks.Helpers
 import Tasks.LegalCNF.Config(LegalCNFConfig(..), LegalCNFInst(..), checkLegalCNFConfig)
-
+import GHC.Real ((%))
 
 
 
@@ -78,7 +78,13 @@ partialGrade LegalCNFInst{..} sol
 
 
 completeGrade :: OutputCapable m => LegalCNFInst -> [Int] -> Rated m
-completeGrade LegalCNFInst{..} = multipleChoice IndefiniteArticle what solutionDisplay solution
+completeGrade LegalCNFInst{..}  sol
+  | null sol && null serialsOfWrong = do
+    reject $ do
+      english "Your solution is incorrect."
+      german "Ihre Lösung ist falsch."
+    pure (0 % 1)
+  | otherwise = multipleChoice IndefiniteArticle what solutionDisplay solution sol
   where
     what = translations $ do
       german "Indizes"

--- a/src/LogicTasks/Syntax/IllegalCnfs.hs
+++ b/src/LogicTasks/Syntax/IllegalCnfs.hs
@@ -11,7 +11,7 @@ import Control.OutputCapable.Blocks (
   german,
   Rated,
   multipleChoice,
-  ArticleToUse (IndefiniteArticle),
+  ArticleToUse (DefiniteArticle),
   translations,
   )
 import Data.List (nub)
@@ -77,7 +77,7 @@ partialGrade LegalCNFInst{..} sol
 
 
 completeGrade :: OutputCapable m => LegalCNFInst -> [Int] -> Rated m
-completeGrade LegalCNFInst{..} = multipleChoice IndefiniteArticle what solutionDisplay solution
+completeGrade LegalCNFInst{..} = multipleChoice DefiniteArticle what solutionDisplay solution
   where
     what = translations $ do
       german "Indizes"

--- a/src/LogicTasks/Syntax/IllegalCnfs.hs
+++ b/src/LogicTasks/Syntax/IllegalCnfs.hs
@@ -19,8 +19,6 @@ import Data.Set (toList)
 import Data.Map as Map (fromAscList)
 import LogicTasks.Helpers
 import Tasks.LegalCNF.Config(LegalCNFConfig(..), LegalCNFInst(..), checkLegalCNFConfig)
-import GHC.Real ((%))
-import Data.List.Extra (notNull)
 
 
 
@@ -79,13 +77,7 @@ partialGrade LegalCNFInst{..} sol
 
 
 completeGrade :: OutputCapable m => LegalCNFInst -> [Int] -> Rated m
-completeGrade LegalCNFInst{..}  sol
-  | null sol && notNull serialsOfRight = do
-    reject $ do
-      english "Your solution is incorrect."
-      german "Ihre Lösung ist falsch."
-    pure (0 % 1)
-  | otherwise = multipleChoice IndefiniteArticle what solutionDisplay solution sol
+completeGrade LegalCNFInst{..} = multipleChoice IndefiniteArticle what solutionDisplay solution
   where
     what = translations $ do
       german "Indizes"

--- a/src/LogicTasks/Syntax/IllegalFormulas.hs
+++ b/src/LogicTasks/Syntax/IllegalFormulas.hs
@@ -14,7 +14,7 @@ import Control.OutputCapable.Blocks (
   german,
   Rated,
   multipleChoice,
-  ArticleToUse (IndefiniteArticle),
+  ArticleToUse (DefiniteArticle),
   translations,
   )
 import Data.List (nub, sort)
@@ -91,7 +91,7 @@ completeGrade
   -> [Int]
   -> Rated m
 completeGrade path LegalPropositionInst{..} sol = reRefuse
-    (multipleChoice IndefiniteArticle what solutionDisplay solution sol)
+    (multipleChoice DefiniteArticle what solutionDisplay solution sol)
     $ when (showSolution && wrongSolution) $ do
       instruct $ do
           english "The following syntax trees represent the well-formed formulas:"

--- a/src/LogicTasks/Syntax/IllegalFormulas.hs
+++ b/src/LogicTasks/Syntax/IllegalFormulas.hs
@@ -11,7 +11,11 @@ import Control.OutputCapable.Blocks (
   OutputCapable,
   ($=<<),
   english,
-  german, Rated, multipleChoice, ArticleToUse (IndefiniteArticle), translations,
+  german,
+  Rated,
+  multipleChoice,
+  ArticleToUse (IndefiniteArticle),
+  translations,
   )
 import Data.List (nub, sort)
 import LogicTasks.Helpers (example, extra, focus, indexed, instruct, reject)

--- a/src/LogicTasks/Syntax/IllegalFormulas.hs
+++ b/src/LogicTasks/Syntax/IllegalFormulas.hs
@@ -27,9 +27,7 @@ import LogicTasks.Syntax.TreeToFormula (cacheTree)
 import Data.Foldable (for_)
 import Data.Maybe (isJust, fromJust)
 import qualified Data.Map as Map (fromAscList)
-import GHC.Real ((%))
 import Control.Applicative (Alternative)
-import Data.List.Extra (notNull)
 
 
 
@@ -92,13 +90,7 @@ completeGrade
   -> LegalPropositionInst
   -> [Int]
   -> Rated m
-completeGrade path LegalPropositionInst{..} sol
-  | null sol && notNull serialsOfRight = do
-    reject $ do
-      english "Your solution is incorrect."
-      german "Ihre Lösung ist falsch."
-    pure (0 % 1)
-  | otherwise = reRefuse
+completeGrade path LegalPropositionInst{..} sol = reRefuse
     (multipleChoice IndefiniteArticle what solutionDisplay solution sol)
     $ when (showSolution && wrongSolution) $ do
       instruct $ do


### PR DESCRIPTION
Basiert auf #89 

`SubTreeSet` ist derzeit für eine Umsetzung mit `multipleChoice` nicht ganz geeignet, da in der Aufgabe nur eine bestimmte Anzahl (also nicht zwingend alle) an Teilformeln angegeben werden muss. Bei `multipleChoice` würde man aber nur die volle Punktzahl erhalten, wenn die Lösung des Nutzers alle Teilformen beinhaltet. Des Weiteren würde bei der Aufgabe ein Konflikt mit dem `Delayed` Parsing auftreten, da die Funktionen dort auf `LangM m` und nicht `LangM' m c` arbeiten.
