### PR TITLE
Replace `allowArrowOperators` with `operatorFrequencies` in `SynTreeConfig`

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -8,6 +8,7 @@ dnf
 Dnf
 DNFs
 DSL
+equi
 fmap
 fmidue
 fno

--- a/.github/linters/.jscpd.json
+++ b/.github/linters/.jscpd.json
@@ -5,7 +5,7 @@
   ],
   "ignore": [
     "**/__snapshots__/**",
-    "examples/**"
+    "**/examples/**"
   ],
   "minLines": 5,
   "max-lines": 1000,

--- a/.github/linters/.jscpd.json
+++ b/.github/linters/.jscpd.json
@@ -4,7 +4,8 @@
     "consoleFull"
   ],
   "ignore": [
-    "**/__snapshots__/**"
+    "**/__snapshots__/**",
+    "examples/**"
   ],
   "minLines": 5,
   "max-lines": 1000,

--- a/examples/logic-tasks-examples.cabal
+++ b/examples/logic-tasks-examples.cabal
@@ -33,6 +33,7 @@ library
   ghc-options: -Wall -Widentities -Wwarn=incomplete-uni-patterns -Wwarn=x-partial -fno-warn-unused-do-bind -fdefer-typed-holes -Werror -Wwarn=unrecognised-warning-flags
   build-depends:
       base >=4.7 && <5
+    , containers
     , hspec
     , logic-tasks
     , output-blocks >=0.2
@@ -48,6 +49,7 @@ test-suite verify-configs
   ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wunused-imports -Wmissing-signatures -Werror
   build-depends:
       base >=4.7 && <5
+    , containers
     , hspec
     , logic-tasks
     , logic-tasks-examples

--- a/examples/package.yaml
+++ b/examples/package.yaml
@@ -7,6 +7,7 @@ dependencies:
   - logic-tasks
   - output-blocks >= 0.2
   - hspec
+  - containers
 
 library:
   source-dirs: src

--- a/examples/src/Syntax/ComposeFormula/Config.hs
+++ b/examples/src/Syntax/ComposeFormula/Config.hs
@@ -1,17 +1,17 @@
 module Syntax.ComposeFormula.Config where
 
-import Prelude hiding (and, or)
 import Tasks.ComposeFormula.Config (
   ComposeFormulaConfig(..), checkComposeFormulaConfig, TreeDisplayMode (TreeDisplay),
   )
 import Tasks.SynTree.Config (
-  SynTreeConfig(..),
-  OperatorFrequencies(..)
+  SynTreeConfig(..)
   )
+import Trees.Types (BinOp(..))
 
 import Test.Hspec
 import Util.VerifyConfig
 import Control.OutputCapable.Blocks (Language(German))
+import qualified Data.Map as Map (fromList)
 
 
 small :: ComposeFormulaConfig
@@ -23,14 +23,14 @@ small = ComposeFormulaConfig
     , maxDepth = 4
     , availableAtoms = "ABCD"
     , minAmountOfUniqueAtoms = 4
-    , operatorFrequencies = OperatorFrequencies
-      { and = 1
-      , or = 1
-      , impl = 0
-      , backImpl = 0
-      , equi = 0
-      , neg = 1
-      }
+    , binOpFrequencies = Map.fromList
+      [ (And, 1)
+      , (Or, 1)
+      , (Impl, 0)
+      , (BackImpl, 0)
+      , (Equi, 0)
+      ]
+    , negOpFrequency = 1
     , maxConsecutiveNegations = 2
     , minUniqueBinOperators = 2
     }
@@ -50,14 +50,14 @@ medium = ComposeFormulaConfig
     , maxDepth = 6
     , availableAtoms = "ABCDE"
     , minAmountOfUniqueAtoms = 5
-    , operatorFrequencies = OperatorFrequencies
-      { and = 1
-      , or = 1
-      , impl = 1
-      , backImpl = 1
-      , equi = 1
-      , neg = 1
-      }
+    , binOpFrequencies = Map.fromList
+      [ (And, 1)
+      , (Or, 1)
+      , (Impl, 1)
+      , (BackImpl, 1)
+      , (Equi, 1)
+      ]
+    , negOpFrequency = 1
     , maxConsecutiveNegations = 2
     , minUniqueBinOperators = 2
     }

--- a/examples/src/Syntax/ComposeFormula/Config.hs
+++ b/examples/src/Syntax/ComposeFormula/Config.hs
@@ -1,10 +1,12 @@
 module Syntax.ComposeFormula.Config where
 
+import Prelude hiding (and, or)
 import Tasks.ComposeFormula.Config (
   ComposeFormulaConfig(..), checkComposeFormulaConfig, TreeDisplayMode (TreeDisplay),
   )
 import Tasks.SynTree.Config (
   SynTreeConfig(..),
+  OperatorFrequencies(..)
   )
 
 import Test.Hspec
@@ -21,7 +23,14 @@ small = ComposeFormulaConfig
     , maxDepth = 4
     , availableAtoms = "ABCD"
     , minAmountOfUniqueAtoms = 4
-    , allowArrowOperators = False
+    , operatorFrequencies = OperatorFrequencies
+      { and = 1
+      , or = 1
+      , impl = 0
+      , backImpl = 0
+      , equi = 0
+      , neg = 1
+      }
     , maxConsecutiveNegations = 2
     , minUniqueBinOperators = 2
     }
@@ -41,7 +50,14 @@ medium = ComposeFormulaConfig
     , maxDepth = 6
     , availableAtoms = "ABCDE"
     , minAmountOfUniqueAtoms = 5
-    , allowArrowOperators = True
+    , operatorFrequencies = OperatorFrequencies
+      { and = 1
+      , or = 1
+      , impl = 1
+      , backImpl = 1
+      , equi = 1
+      , neg = 1
+      }
     , maxConsecutiveNegations = 2
     , minUniqueBinOperators = 2
     }

--- a/examples/src/Syntax/DecomposeFormula/Config.hs
+++ b/examples/src/Syntax/DecomposeFormula/Config.hs
@@ -49,8 +49,8 @@ medium = DecomposeFormulaConfig
     , operatorFrequencies = OperatorFrequencies
       { and = 1
       , or = 1
-      , impl = 1
-      , backImpl = 1
+      , impl = 0
+      , backImpl = 0
       , equi = 1
       , neg = 1
       }

--- a/examples/src/Syntax/DecomposeFormula/Config.hs
+++ b/examples/src/Syntax/DecomposeFormula/Config.hs
@@ -1,9 +1,11 @@
 module Syntax.DecomposeFormula.Config where
+import Prelude hiding (and, or)
 import Tasks.DecomposeFormula.Config (
   DecomposeFormulaConfig(..), checkDecomposeFormulaConfig,
   )
 import Tasks.SynTree.Config (
   SynTreeConfig(..),
+  OperatorFrequencies(..)
   )
 import Test.Hspec
 import Util.VerifyConfig
@@ -18,7 +20,14 @@ small = DecomposeFormulaConfig
     , maxDepth = 4
     , availableAtoms = "ABCD"
     , minAmountOfUniqueAtoms = 4
-    , allowArrowOperators = False
+    , operatorFrequencies = OperatorFrequencies
+      { and = 1
+      , or = 1
+      , impl = 0
+      , backImpl = 0
+      , equi = 0
+      , neg = 1
+      }
     , maxConsecutiveNegations = 2
     , minUniqueBinOperators = 2
     }
@@ -37,7 +46,14 @@ medium = DecomposeFormulaConfig
     , maxDepth = 6
     , availableAtoms = "ABCDE"
     , minAmountOfUniqueAtoms = 5
-    , allowArrowOperators = True
+    , operatorFrequencies = OperatorFrequencies
+      { and = 1
+      , or = 1
+      , impl = 1
+      , backImpl = 1
+      , equi = 1
+      , neg = 1
+      }
     , maxConsecutiveNegations = 2
     , minUniqueBinOperators = 3
     }

--- a/examples/src/Syntax/DecomposeFormula/Config.hs
+++ b/examples/src/Syntax/DecomposeFormula/Config.hs
@@ -1,15 +1,15 @@
 module Syntax.DecomposeFormula.Config where
-import Prelude hiding (and, or)
 import Tasks.DecomposeFormula.Config (
   DecomposeFormulaConfig(..), checkDecomposeFormulaConfig,
   )
 import Tasks.SynTree.Config (
-  SynTreeConfig(..),
-  OperatorFrequencies(..)
+  SynTreeConfig(..)
   )
+import Trees.Types (BinOp(..))
 import Test.Hspec
 import Util.VerifyConfig
 import Control.OutputCapable.Blocks (Language(German))
+import qualified Data.Map as Map (fromList)
 
 small :: DecomposeFormulaConfig
 small = DecomposeFormulaConfig
@@ -20,14 +20,14 @@ small = DecomposeFormulaConfig
     , maxDepth = 4
     , availableAtoms = "ABCD"
     , minAmountOfUniqueAtoms = 4
-    , operatorFrequencies = OperatorFrequencies
-      { and = 1
-      , or = 1
-      , impl = 0
-      , backImpl = 0
-      , equi = 0
-      , neg = 1
-      }
+    , binOpFrequencies = Map.fromList
+      [ (And, 1)
+      , (Or, 1)
+      , (Impl, 0)
+      , (BackImpl, 0)
+      , (Equi, 0)
+      ]
+    , negOpFrequency = 1
     , maxConsecutiveNegations = 2
     , minUniqueBinOperators = 2
     }
@@ -46,14 +46,14 @@ medium = DecomposeFormulaConfig
     , maxDepth = 6
     , availableAtoms = "ABCDE"
     , minAmountOfUniqueAtoms = 5
-    , operatorFrequencies = OperatorFrequencies
-      { and = 1
-      , or = 1
-      , impl = 0
-      , backImpl = 0
-      , equi = 1
-      , neg = 1
-      }
+    , binOpFrequencies = Map.fromList
+      [ (And, 1)
+      , (Or, 1)
+      , (Impl, 0)
+      , (BackImpl, 0)
+      , (Equi, 1)
+      ]
+    , negOpFrequency = 1
     , maxConsecutiveNegations = 2
     , minUniqueBinOperators = 3
     }

--- a/examples/src/Syntax/InvalidFormulas/Config.hs
+++ b/examples/src/Syntax/InvalidFormulas/Config.hs
@@ -1,10 +1,12 @@
 module Syntax.InvalidFormulas.Config where
 
+import Prelude hiding (and, or)
 import Tasks.LegalProposition.Config (
   LegalPropositionConfig(..), checkLegalPropositionConfig,
   )
 import Tasks.SynTree.Config (
   SynTreeConfig(..),
+  OperatorFrequencies(..)
   )
 import Test.Hspec
 import Util.VerifyConfig
@@ -20,7 +22,14 @@ task01 = LegalPropositionConfig
     , maxDepth = 5
     , availableAtoms = "ABCDE"
     , minAmountOfUniqueAtoms = 5
-    , allowArrowOperators = False
+    , operatorFrequencies = OperatorFrequencies
+      { and = 1
+      , or = 1
+      , impl = 0
+      , backImpl = 0
+      , equi = 0
+      , neg = 1
+      }
     , maxConsecutiveNegations = 2
     , minUniqueBinOperators = 2
     }
@@ -41,7 +50,14 @@ task17 = LegalPropositionConfig
     , maxDepth = 6
     , availableAtoms = "ABCDEF"
     , minAmountOfUniqueAtoms = 6
-    , allowArrowOperators = True
+    , operatorFrequencies = OperatorFrequencies
+      { and = 1
+      , or = 1
+      , impl = 1
+      , backImpl = 1
+      , equi = 1
+      , neg = 1
+      }
     , maxConsecutiveNegations = 2
     , minUniqueBinOperators = 3
     }

--- a/examples/src/Syntax/InvalidFormulas/Config.hs
+++ b/examples/src/Syntax/InvalidFormulas/Config.hs
@@ -1,16 +1,16 @@
 module Syntax.InvalidFormulas.Config where
 
-import Prelude hiding (and, or)
 import Tasks.LegalProposition.Config (
   LegalPropositionConfig(..), checkLegalPropositionConfig,
   )
 import Tasks.SynTree.Config (
-  SynTreeConfig(..),
-  OperatorFrequencies(..)
+  SynTreeConfig(..)
   )
+import Trees.Types (BinOp(..))
 import Test.Hspec
 import Util.VerifyConfig
 import Control.OutputCapable.Blocks (Language(German))
+import qualified Data.Map as Map (fromList)
 
 -- Weight 0.33
 task01 :: LegalPropositionConfig
@@ -22,14 +22,14 @@ task01 = LegalPropositionConfig
     , maxDepth = 5
     , availableAtoms = "ABCDE"
     , minAmountOfUniqueAtoms = 5
-    , operatorFrequencies = OperatorFrequencies
-      { and = 1
-      , or = 1
-      , impl = 0
-      , backImpl = 0
-      , equi = 0
-      , neg = 1
-      }
+    , binOpFrequencies = Map.fromList
+      [ (And, 1)
+      , (Or, 1)
+      , (Impl, 0)
+      , (BackImpl, 0)
+      , (Equi, 0)
+      ]
+    , negOpFrequency = 1
     , maxConsecutiveNegations = 2
     , minUniqueBinOperators = 2
     }
@@ -50,14 +50,14 @@ task17 = LegalPropositionConfig
     , maxDepth = 6
     , availableAtoms = "ABCDEF"
     , minAmountOfUniqueAtoms = 6
-    , operatorFrequencies = OperatorFrequencies
-      { and = 1
-      , or = 1
-      , impl = 1
-      , backImpl = 1
-      , equi = 1
-      , neg = 1
-      }
+    , binOpFrequencies = Map.fromList
+      [ (And, 1)
+      , (Or, 1)
+      , (Impl, 1)
+      , (BackImpl, 1)
+      , (Equi, 1)
+      ]
+    , negOpFrequency = 1
     , maxConsecutiveNegations = 2
     , minUniqueBinOperators = 3
     }

--- a/examples/src/Syntax/RemoveBrackets/Config.hs
+++ b/examples/src/Syntax/RemoveBrackets/Config.hs
@@ -1,16 +1,16 @@
 module Syntax.RemoveBrackets.Config where
 
-import Prelude hiding (and, or)
 import Tasks.SuperfluousBrackets.Config (
   SuperfluousBracketsConfig(..), checkSuperfluousBracketsConfig,
   )
 import Tasks.SynTree.Config (
-  SynTreeConfig(..),
-  OperatorFrequencies(..)
+  SynTreeConfig(..)
   )
+import Trees.Types (BinOp(..))
 import Control.OutputCapable.Blocks (english, german, translations, Language (German))
 import Test.Hspec
 import Util.VerifyConfig
+import qualified Data.Map as Map (fromList)
 
 -- Weight 0.33
 task02 :: SuperfluousBracketsConfig
@@ -22,14 +22,14 @@ task02 = SuperfluousBracketsConfig
     , maxDepth = 5
     , availableAtoms = "ABCDE"
     , minAmountOfUniqueAtoms = 5
-    , operatorFrequencies = OperatorFrequencies
-      { and = 1
-      , or = 1
-      , impl = 0
-      , backImpl = 0
-      , equi = 0
-      , neg = 1
-      }
+    , binOpFrequencies = Map.fromList
+      [ (And, 1)
+      , (Or, 1)
+      , (Impl, 0)
+      , (BackImpl, 0)
+      , (Equi, 0)
+      ]
+    , negOpFrequency = 1
     , maxConsecutiveNegations = 2
     , minUniqueBinOperators = 2
     }
@@ -52,14 +52,14 @@ task05 = SuperfluousBracketsConfig
     , maxDepth = 6
     , availableAtoms = "ABCDEF"
     , minAmountOfUniqueAtoms = 6
-    , operatorFrequencies = OperatorFrequencies
-      { and = 1
-      , or = 1
-      , impl = 1
-      , backImpl = 1
-      , equi = 1
-      , neg = 1
-      }
+    , binOpFrequencies = Map.fromList
+      [ (And, 1)
+      , (Or, 1)
+      , (Impl, 1)
+      , (BackImpl, 1)
+      , (Equi, 1)
+      ]
+    , negOpFrequency = 1
     , maxConsecutiveNegations = 2
     , minUniqueBinOperators = 3
     }

--- a/examples/src/Syntax/RemoveBrackets/Config.hs
+++ b/examples/src/Syntax/RemoveBrackets/Config.hs
@@ -1,10 +1,12 @@
 module Syntax.RemoveBrackets.Config where
 
+import Prelude hiding (and, or)
 import Tasks.SuperfluousBrackets.Config (
   SuperfluousBracketsConfig(..), checkSuperfluousBracketsConfig,
   )
 import Tasks.SynTree.Config (
   SynTreeConfig(..),
+  OperatorFrequencies(..)
   )
 import Control.OutputCapable.Blocks (english, german, translations, Language (German))
 import Test.Hspec
@@ -20,7 +22,14 @@ task02 = SuperfluousBracketsConfig
     , maxDepth = 5
     , availableAtoms = "ABCDE"
     , minAmountOfUniqueAtoms = 5
-    , allowArrowOperators = False
+    , operatorFrequencies = OperatorFrequencies
+      { and = 1
+      , or = 1
+      , impl = 0
+      , backImpl = 0
+      , equi = 0
+      , neg = 1
+      }
     , maxConsecutiveNegations = 2
     , minUniqueBinOperators = 2
     }
@@ -43,7 +52,14 @@ task05 = SuperfluousBracketsConfig
     , maxDepth = 6
     , availableAtoms = "ABCDEF"
     , minAmountOfUniqueAtoms = 6
-    , allowArrowOperators = True
+    , operatorFrequencies = OperatorFrequencies
+      { and = 1
+      , or = 1
+      , impl = 1
+      , backImpl = 1
+      , equi = 1
+      , neg = 1
+      }
     , maxConsecutiveNegations = 2
     , minUniqueBinOperators = 3
     }

--- a/examples/src/Syntax/Subformulas/Config.hs
+++ b/examples/src/Syntax/Subformulas/Config.hs
@@ -1,11 +1,13 @@
 module Syntax.Subformulas.Config where
 
+import Prelude hiding (and, or)
 import Test.Hspec
 import Tasks.SubTree.Config (
   SubTreeConfig(..), checkSubTreeConfig,
   )
 import Tasks.SynTree.Config (
   SynTreeConfig(..),
+  OperatorFrequencies(..)
   )
 import Util.VerifyConfig
 import Control.OutputCapable.Blocks (Language(German))
@@ -19,7 +21,14 @@ medium = SubTreeConfig
     , maxDepth = 6
     , availableAtoms = "ABCDE"
     , minAmountOfUniqueAtoms = 5
-    , allowArrowOperators = True
+    , operatorFrequencies = OperatorFrequencies
+      { and = 1
+      , or = 1
+      , impl = 1
+      , backImpl = 1
+      , equi = 1
+      , neg = 1
+      }
     , maxConsecutiveNegations = 2
     , minUniqueBinOperators = 2
     }

--- a/examples/src/Syntax/Subformulas/Config.hs
+++ b/examples/src/Syntax/Subformulas/Config.hs
@@ -1,16 +1,16 @@
 module Syntax.Subformulas.Config where
 
-import Prelude hiding (and, or)
 import Test.Hspec
 import Tasks.SubTree.Config (
   SubTreeConfig(..), checkSubTreeConfig,
   )
 import Tasks.SynTree.Config (
-  SynTreeConfig(..),
-  OperatorFrequencies(..)
+  SynTreeConfig(..)
   )
+import Trees.Types (BinOp(..))
 import Util.VerifyConfig
 import Control.OutputCapable.Blocks (Language(German))
+import qualified Data.Map as Map (fromList)
 
 medium :: SubTreeConfig
 medium = SubTreeConfig
@@ -21,14 +21,14 @@ medium = SubTreeConfig
     , maxDepth = 6
     , availableAtoms = "ABCDE"
     , minAmountOfUniqueAtoms = 5
-    , operatorFrequencies = OperatorFrequencies
-      { and = 1
-      , or = 1
-      , impl = 1
-      , backImpl = 1
-      , equi = 1
-      , neg = 1
-      }
+    , binOpFrequencies = Map.fromList
+      [ (And, 1)
+      , (Or, 1)
+      , (Impl, 1)
+      , (BackImpl, 1)
+      , (Equi, 1)
+      ]
+    , negOpFrequency = 1
     , maxConsecutiveNegations = 2
     , minUniqueBinOperators = 2
     }

--- a/examples/src/Syntax/TreeToFormula/Config.hs
+++ b/examples/src/Syntax/TreeToFormula/Config.hs
@@ -1,17 +1,17 @@
 module Syntax.TreeToFormula.Config where
 
-import Prelude hiding (and, or)
 import Test.Hspec
 
 import Tasks.SynTree.Config (
-  SynTreeConfig(..),
-  OperatorFrequencies(..)
+  SynTreeConfig(..)
   )
+import Trees.Types (BinOp(..))
 import Tasks.TreeToFormula.Config (
   TreeToFormulaConfig(..),checkTreeToFormulaConfig,
   )
 import Util.VerifyConfig
 import Control.OutputCapable.Blocks (Language(German))
+import qualified Data.Map as Map (fromList)
 
 -- Weight 0.34
 task03 :: TreeToFormulaConfig
@@ -23,14 +23,14 @@ task03 = TreeToFormulaConfig
     , maxDepth = 5
     , availableAtoms = "ABCDE"
     , minAmountOfUniqueAtoms = 5
-    , operatorFrequencies = OperatorFrequencies
-      { and = 1
-      , or = 1
-      , impl = 0
-      , backImpl = 0
-      , equi = 0
-      , neg = 1
-      }
+    , binOpFrequencies = Map.fromList
+      [ (And, 1)
+      , (Or, 1)
+      , (Impl, 0)
+      , (BackImpl, 0)
+      , (Equi, 0)
+      ]
+    , negOpFrequency = 1
     , maxConsecutiveNegations = 2
     , minUniqueBinOperators = 2
     }
@@ -50,14 +50,14 @@ task04 =  TreeToFormulaConfig
     , maxDepth = 9
     , availableAtoms = "ABCDEFG"
     , minAmountOfUniqueAtoms = 7
-    , operatorFrequencies = OperatorFrequencies
-      { and = 1
-      , or = 1
-      , impl = 0
-      , backImpl = 0
-      , equi = 0
-      , neg = 1
-      }
+    , binOpFrequencies = Map.fromList
+      [ (And, 1)
+      , (Or, 1)
+      , (Impl, 0)
+      , (BackImpl, 0)
+      , (Equi, 0)
+      ]
+    , negOpFrequency = 1
     , maxConsecutiveNegations = 3
     , minUniqueBinOperators = 2
     }

--- a/examples/src/Syntax/TreeToFormula/Config.hs
+++ b/examples/src/Syntax/TreeToFormula/Config.hs
@@ -1,9 +1,11 @@
 module Syntax.TreeToFormula.Config where
 
+import Prelude hiding (and, or)
 import Test.Hspec
 
 import Tasks.SynTree.Config (
   SynTreeConfig(..),
+  OperatorFrequencies(..)
   )
 import Tasks.TreeToFormula.Config (
   TreeToFormulaConfig(..),checkTreeToFormulaConfig,
@@ -21,7 +23,14 @@ task03 = TreeToFormulaConfig
     , maxDepth = 5
     , availableAtoms = "ABCDE"
     , minAmountOfUniqueAtoms = 5
-    , allowArrowOperators = False
+    , operatorFrequencies = OperatorFrequencies
+      { and = 1
+      , or = 1
+      , impl = 0
+      , backImpl = 0
+      , equi = 0
+      , neg = 1
+      }
     , maxConsecutiveNegations = 2
     , minUniqueBinOperators = 2
     }
@@ -41,7 +50,14 @@ task04 =  TreeToFormulaConfig
     , maxDepth = 9
     , availableAtoms = "ABCDEFG"
     , minAmountOfUniqueAtoms = 7
-    , allowArrowOperators = True
+    , operatorFrequencies = OperatorFrequencies
+      { and = 1
+      , or = 1
+      , impl = 0
+      , backImpl = 0
+      , equi = 0
+      , neg = 1
+      }
     , maxConsecutiveNegations = 3
     , minUniqueBinOperators = 2
     }

--- a/src/Tasks/ComposeFormula/Config.hs
+++ b/src/Tasks/ComposeFormula/Config.hs
@@ -10,6 +10,7 @@ module Tasks.ComposeFormula.Config (
     TreeDisplayMode(..)
     ) where
 
+-- jscpd:ignore-start
 import Tasks.SynTree.Config (SynTreeConfig(..), defaultSynTreeConfig, checkSynTreeConfig, OperatorFrequencies (..))
 import Data.Map (Map)
 import Trees.Types (SynTree(..), BinOp(..))
@@ -17,6 +18,7 @@ import Data.Typeable
 import GHC.Generics
 import Control.OutputCapable.Blocks (LangM, Language, OutputCapable, english, german)
 import LogicTasks.Helpers (reject)
+-- jscpd:ignore-end
 
 data TreeDisplayMode = FormulaDisplay | TreeDisplay deriving (Show,Eq, Enum, Bounded)
 

--- a/src/Tasks/ComposeFormula/Config.hs
+++ b/src/Tasks/ComposeFormula/Config.hs
@@ -11,8 +11,9 @@ module Tasks.ComposeFormula.Config (
     ) where
 
 -- jscpd:ignore-start
-import Tasks.SynTree.Config (SynTreeConfig(..), defaultSynTreeConfig, checkSynTreeConfig, OperatorFrequencies (..))
+import Tasks.SynTree.Config (SynTreeConfig(..), defaultSynTreeConfig, checkSynTreeConfig)
 import Data.Map (Map)
+import qualified Data.Map as Map (fromList)
 import Trees.Types (SynTree(..), BinOp(..))
 import Data.Typeable
 import GHC.Generics
@@ -35,14 +36,13 @@ data ComposeFormulaConfig = ComposeFormulaConfig {
 defaultComposeFormulaConfig :: ComposeFormulaConfig
 defaultComposeFormulaConfig = ComposeFormulaConfig
     { syntaxTreeConfig = defaultSynTreeConfig
-      { operatorFrequencies = OperatorFrequencies
-        { and = 1
-        , or = 1
-        , impl = 1
-        , backImpl = 1
-        , equi = 1
-        , neg = 1
-        }
+      { binOpFrequencies = Map.fromList
+        [ (And, 1)
+        , (Or, 1)
+        , (Impl, 1)
+        , (BackImpl, 1)
+        , (Equi, 1)
+        ]
       }
     , treeDisplayModes = (TreeDisplay, TreeDisplay)
     , extraHintsOnAssociativity = True

--- a/src/Tasks/ComposeFormula/Config.hs
+++ b/src/Tasks/ComposeFormula/Config.hs
@@ -10,7 +10,7 @@ module Tasks.ComposeFormula.Config (
     TreeDisplayMode(..)
     ) where
 
-import Tasks.SynTree.Config (SynTreeConfig(..), defaultSynTreeConfig, checkSynTreeConfig)
+import Tasks.SynTree.Config (SynTreeConfig(..), defaultSynTreeConfig, checkSynTreeConfig, OperatorFrequencies (..))
 import Data.Map (Map)
 import Trees.Types (SynTree(..), BinOp(..))
 import Data.Typeable
@@ -32,7 +32,16 @@ data ComposeFormulaConfig = ComposeFormulaConfig {
 
 defaultComposeFormulaConfig :: ComposeFormulaConfig
 defaultComposeFormulaConfig = ComposeFormulaConfig
-    { syntaxTreeConfig = defaultSynTreeConfig { allowArrowOperators = True }
+    { syntaxTreeConfig = defaultSynTreeConfig
+      { operatorFrequencies = OperatorFrequencies
+        { and = 1
+        , or = 1
+        , impl = 1
+        , backImpl = 1
+        , equi = 1
+        , neg = 1
+        }
+      }
     , treeDisplayModes = (TreeDisplay, TreeDisplay)
     , extraHintsOnAssociativity = True
     , extraText = Nothing

--- a/src/Tasks/DecomposeFormula/Config.hs
+++ b/src/Tasks/DecomposeFormula/Config.hs
@@ -9,9 +9,9 @@ module Tasks.DecomposeFormula.Config (
     checkDecomposeFormulaConfig
     ) where
 
-import Prelude hiding (and, or)
-import Tasks.SynTree.Config (SynTreeConfig(..), defaultSynTreeConfig, checkSynTreeConfig, OperatorFrequencies (..))
+import Tasks.SynTree.Config (SynTreeConfig(..), defaultSynTreeConfig, checkSynTreeConfig)
 import Data.Map (Map)
+import qualified Data.Map as Map (fromList, findWithDefault)
 import Trees.Types (SynTree(..), BinOp(..))
 import Data.Typeable
 import GHC.Generics
@@ -30,14 +30,13 @@ data DecomposeFormulaConfig = DecomposeFormulaConfig {
 defaultDecomposeFormulaConfig :: DecomposeFormulaConfig
 defaultDecomposeFormulaConfig = DecomposeFormulaConfig
     { syntaxTreeConfig = defaultSynTreeConfig
-      { operatorFrequencies = OperatorFrequencies
-        { and = 1
-        , or = 1
-        , impl = 0
-        , backImpl = 0
-        , equi = 1
-        , neg = 1
-        }
+      { binOpFrequencies = Map.fromList
+        [ (And, 1)
+        , (Or, 1)
+        , (Impl, 1)
+        , (BackImpl, 1)
+        , (Equi, 1)
+        ]
       }
     , extraHintsOnAssociativity = True
     , extraText = Nothing
@@ -52,20 +51,18 @@ checkDecomposeFormulaConfig config@DecomposeFormulaConfig{..} =
   checkSynTreeConfig syntaxTreeConfig *> checkAdditionalConfig config
 
 checkAdditionalConfig :: OutputCapable m => DecomposeFormulaConfig -> LangM m
-checkAdditionalConfig DecomposeFormulaConfig {syntaxTreeConfig=SynTreeConfig {operatorFrequencies=OperatorFrequencies{..},..}}
+checkAdditionalConfig DecomposeFormulaConfig {syntaxTreeConfig=SynTreeConfig {..}}
     | minUniqueBinOperators < 1 = reject $ do
         english "There should be a positive number of (unique) operators."
         german "Es sollte eine positive Anzahl an (unterschiedlichen) Operatoren geben."
     | minNodes < 7 = reject $ do
         english "Minimum number of nodes restricts the number of possible subtrees too much."
         german "Minimale Anzahl an Knoten schränkt die Anzahl der möglichen Teilbäume zu stark ein."
-    | all (== 0) [and, or, equi] = reject $ do
+    | all ((== 0) . freq) [And, Or, Equi] = reject $ do
         english "At least one of the following operators must have a frequency greater than 0: And, Or, Equi"
         german "Mindestens einer der folgenden Operatoren muss eine Frequenz größer als 0 besitzen: And, Or, Equi"
-    | any (> 0) [impl, backImpl] = reject $ do
-        english "Both implication operators are currently not implemented for this task."
-        german "Beide Operatoren für Implikation sind derzeit für diese Aufgabe nicht implementiert."
     | otherwise = pure ()
+    where freq op = Map.findWithDefault (0 :: Int) op binOpFrequencies
 
 data DecomposeFormulaInst = DecomposeFormulaInst
                { tree :: SynTree BinOp Char

--- a/src/Tasks/DecomposeFormula/Config.hs
+++ b/src/Tasks/DecomposeFormula/Config.hs
@@ -33,8 +33,8 @@ defaultDecomposeFormulaConfig = DecomposeFormulaConfig
       { operatorFrequencies = OperatorFrequencies
         { and = 1
         , or = 1
-        , impl = 1
-        , backImpl = 1
+        , impl = 0
+        , backImpl = 0
         , equi = 1
         , neg = 1
         }

--- a/src/Tasks/DecomposeFormula/Config.hs
+++ b/src/Tasks/DecomposeFormula/Config.hs
@@ -9,7 +9,7 @@ module Tasks.DecomposeFormula.Config (
     checkDecomposeFormulaConfig
     ) where
 
-import Tasks.SynTree.Config (SynTreeConfig(..), defaultSynTreeConfig, checkSynTreeConfig)
+import Tasks.SynTree.Config (SynTreeConfig(..), defaultSynTreeConfig, checkSynTreeConfig, OperatorFrequencies (..))
 import Data.Map (Map)
 import Trees.Types (SynTree(..), BinOp(..))
 import Data.Typeable
@@ -28,7 +28,16 @@ data DecomposeFormulaConfig = DecomposeFormulaConfig {
 
 defaultDecomposeFormulaConfig :: DecomposeFormulaConfig
 defaultDecomposeFormulaConfig = DecomposeFormulaConfig
-    { syntaxTreeConfig = defaultSynTreeConfig { allowArrowOperators = True }
+    { syntaxTreeConfig = defaultSynTreeConfig
+      { operatorFrequencies = OperatorFrequencies
+        { and = 1
+        , or = 1
+        , impl = 1
+        , backImpl = 1
+        , equi = 1
+        , neg = 1
+        }
+      }
     , extraHintsOnAssociativity = True
     , extraText = Nothing
     , printSolution = True

--- a/src/Tasks/DecomposeFormula/Config.hs
+++ b/src/Tasks/DecomposeFormula/Config.hs
@@ -66,6 +66,7 @@ checkAdditionalConfig DecomposeFormulaConfig {syntaxTreeConfig=SynTreeConfig {op
         english "Both implication operators are currently not implemented for this task."
         german "Beide Operatoren für Implikation sind derzeit für diese Aufgabe nicht implementiert."
     | otherwise = pure ()
+
 data DecomposeFormulaInst = DecomposeFormulaInst
                { tree :: SynTree BinOp Char
                , addExtraHintsOnAssociativity :: Bool

--- a/src/Tasks/LegalProposition/Config.hs
+++ b/src/Tasks/LegalProposition/Config.hs
@@ -17,7 +17,7 @@ import Data.Map (Map)
 
 import LogicTasks.Helpers (reject)
 import Trees.Helpers (maxLeavesForNodes)
-import Tasks.SynTree.Config(SynTreeConfig(..), checkSynTreeConfig, defaultSynTreeConfig)
+import Tasks.SynTree.Config(SynTreeConfig(..), checkSynTreeConfig, defaultSynTreeConfig, arrowOperatorsAllowed)
 import Trees.Types (SynTree, BinOp)
 import Tasks.LegalProposition.Helpers (formulaAmount)
 
@@ -53,7 +53,7 @@ checkLegalPropositionConfig config@LegalPropositionConfig {..} =
 
 
 checkAdditionalConfig :: OutputCapable m => LegalPropositionConfig -> LangM m
-checkAdditionalConfig config@LegalPropositionConfig {syntaxTreeConfig = SynTreeConfig {..}, formulas, illegals, bracketFormulas}
+checkAdditionalConfig config@LegalPropositionConfig {syntaxTreeConfig = treeCfg@SynTreeConfig {..}, formulas, illegals, bracketFormulas}
     | minNodes < 3 = reject $ do
         english "form A and ~A is meaningless in this kind of issue"
         german "Minimale Anzahl an Blättern unter 3 kann nur triviale Aufgaben erzeugen."
@@ -69,7 +69,7 @@ checkAdditionalConfig config@LegalPropositionConfig {syntaxTreeConfig = SynTreeC
     | formulas < illegals + bracketFormulas = reject $ do
         english "The number of formulas cannot be less than the sum of bracket Formulas and illegal ones."
         german "Die Anzahl der Formeln kann nicht niedriger als die Summe von falschen und richtigen Formeln."
-    | let leaves = maxLeavesForNodes maxNodes, (if allowArrowOperators then 4 else 2) ^ (maxNodes - leaves) < formulas
+    | let leaves = maxLeavesForNodes maxNodes, (if arrowOperatorsAllowed treeCfg then 4 else 2) ^ (maxNodes - leaves) < formulas
       = reject $ do
         english "Settings may result in extremely large formulas."
         german "Einstellungen führen zu extrem großen Formeln."

--- a/src/Tasks/LegalProposition/Helpers.hs
+++ b/src/Tasks/LegalProposition/Helpers.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE RecordWildCards #-}
 module Tasks.LegalProposition.Helpers where
-import Tasks.SynTree.Config (SynTreeConfig (..), arrowOperatorsAllowed)
-import Trees.Types (BinOp)
+import Tasks.SynTree.Config (SynTreeConfig (..))
+import qualified Data.Map as Map (filter)
 
 formulaAmount :: SynTreeConfig -> Integer
-formulaAmount cfg@SynTreeConfig{..} =
-  (if arrowOperatorsAllowed cfg then fromIntegral (length [minBound..maxBound :: BinOp]) else 2)
-    ^ ((maxNodes + 1) `div` 2 - minUniqueBinOperators)
+formulaAmount SynTreeConfig{..} =
+  let availableOperators = Map.filter (> 0) binOpFrequencies
+    in fromIntegral (length availableOperators) ^ ((maxNodes + 1) `div` 2 - minUniqueBinOperators)

--- a/src/Tasks/LegalProposition/Helpers.hs
+++ b/src/Tasks/LegalProposition/Helpers.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE RecordWildCards #-}
 module Tasks.LegalProposition.Helpers where
-import Tasks.SynTree.Config (SynTreeConfig (..))
+import Tasks.SynTree.Config (SynTreeConfig (..), arrowOperatorsAllowed)
 import Trees.Types (BinOp)
 
 formulaAmount :: SynTreeConfig -> Integer
-formulaAmount SynTreeConfig{..} =
-  (if allowArrowOperators then fromIntegral (length [minBound..maxBound :: BinOp]) else 2)
+formulaAmount cfg@SynTreeConfig{..} =
+  (if arrowOperatorsAllowed cfg then fromIntegral (length [minBound..maxBound :: BinOp]) else 2)
     ^ ((maxNodes + 1) `div` 2 - minUniqueBinOperators)

--- a/src/Tasks/SubTree/Quiz.hs
+++ b/src/Tasks/SubTree/Quiz.hs
@@ -10,7 +10,7 @@ import Trees.Generate (genSynTree)
 import Test.QuickCheck (Gen, suchThat)
 
 import Tasks.SubTree.Config (SubTreeConfig(..), SubTreeInst(..))
-import Tasks.SynTree.Config (SynTreeConfig(..))
+import Tasks.SynTree.Config (arrowOperatorsAllowed)
 import Trees.Helpers (allNotLeafSubTrees, noSameSubTree)
 
 
@@ -26,7 +26,7 @@ generateSubTreeInst SubTreeConfig {..} = do
       { tree
       , minInputTrees = minSubTrees
       , correctTrees = correctTrees
-      , showArrowOperators = allowArrowOperators syntaxTreeConfig
+      , showArrowOperators = arrowOperatorsAllowed syntaxTreeConfig
       , showSolution = printSolution
       , addText = extraText
       , unicodeAllowed = offerUnicodeInput

--- a/src/Tasks/SubTree/Quiz.hs
+++ b/src/Tasks/SubTree/Quiz.hs
@@ -10,8 +10,10 @@ import Trees.Generate (genSynTree)
 import Test.QuickCheck (Gen, suchThat)
 
 import Tasks.SubTree.Config (SubTreeConfig(..), SubTreeInst(..))
-import Tasks.SynTree.Config (arrowOperatorsAllowed)
+import Tasks.SynTree.Config (SynTreeConfig(binOpFrequencies))
 import Trees.Helpers (allNotLeafSubTrees, noSameSubTree)
+import Trees.Types (BinOp(..))
+import qualified Data.Map as Map (keys)
 
 
 
@@ -26,7 +28,7 @@ generateSubTreeInst SubTreeConfig {..} = do
       { tree
       , minInputTrees = minSubTrees
       , correctTrees = correctTrees
-      , showArrowOperators = arrowOperatorsAllowed syntaxTreeConfig
+      , showArrowOperators = any (`elem` Map.keys (binOpFrequencies syntaxTreeConfig)) [Impl, BackImpl, Equi]
       , showSolution = printSolution
       , addText = extraText
       , unicodeAllowed = offerUnicodeInput

--- a/src/Tasks/SuperfluousBrackets/Config.hs
+++ b/src/Tasks/SuperfluousBrackets/Config.hs
@@ -16,9 +16,9 @@ import GHC.Generics (Generic)
 import Data.Map (Map)
 
 import LogicTasks.Helpers (reject)
-import Tasks.SynTree.Config(SynTreeConfig(..), checkSynTreeConfig, defaultSynTreeConfig, OperatorFrequencies (..))
-import Trees.Types (BinOp, SynTree)
-
+import Tasks.SynTree.Config(SynTreeConfig(..), checkSynTreeConfig, defaultSynTreeConfig)
+import Trees.Types (BinOp(..), SynTree)
+import qualified Data.Map as Map (fromList)
 
 
 
@@ -39,14 +39,13 @@ defaultSuperfluousBracketsConfig =
     SuperfluousBracketsConfig
     {
       syntaxTreeConfig = defaultSynTreeConfig
-      { operatorFrequencies = OperatorFrequencies
-        { and = 1
-        , or = 1
-        , impl = 1
-        , backImpl = 1
-        , equi = 1
-        , neg = 1
-        }
+      { binOpFrequencies = Map.fromList
+        [ (And, 1)
+        , (Or, 1)
+        , (Impl, 1)
+        , (BackImpl, 1)
+        , (Equi, 1)
+        ]
       , minUniqueBinOperators = 2
       }
     , superfluousBracketPairs = 2

--- a/src/Tasks/SuperfluousBrackets/Config.hs
+++ b/src/Tasks/SuperfluousBrackets/Config.hs
@@ -16,7 +16,7 @@ import GHC.Generics (Generic)
 import Data.Map (Map)
 
 import LogicTasks.Helpers (reject)
-import Tasks.SynTree.Config(SynTreeConfig(..), checkSynTreeConfig, defaultSynTreeConfig)
+import Tasks.SynTree.Config(SynTreeConfig(..), checkSynTreeConfig, defaultSynTreeConfig, OperatorFrequencies (..))
 import Trees.Types (BinOp, SynTree)
 
 
@@ -38,7 +38,17 @@ defaultSuperfluousBracketsConfig :: SuperfluousBracketsConfig
 defaultSuperfluousBracketsConfig =
     SuperfluousBracketsConfig
     {
-      syntaxTreeConfig = defaultSynTreeConfig { allowArrowOperators = True, minUniqueBinOperators = 2 }
+      syntaxTreeConfig = defaultSynTreeConfig
+      { operatorFrequencies = OperatorFrequencies
+        { and = 1
+        , or = 1
+        , impl = 1
+        , backImpl = 1
+        , equi = 1
+        , neg = 1
+        }
+      , minUniqueBinOperators = 2
+      }
     , superfluousBracketPairs = 2
     , extraText = Nothing
     , printSolution = False

--- a/src/Tasks/SuperfluousBrackets/Quiz.hs
+++ b/src/Tasks/SuperfluousBrackets/Quiz.hs
@@ -9,7 +9,7 @@ import Test.QuickCheck (Gen, suchThat)
 
 import Tasks.SuperfluousBrackets.Config (SuperfluousBracketsConfig(..), SuperfluousBracketsInst(..))
 import Tasks.SuperfluousBrackets.PrintSuperfluousBrackets (superfluousBracketsDisplay)
-import Tasks.SynTree.Config (SynTreeConfig(..))
+import Tasks.SynTree.Config (arrowOperatorsAllowed)
 import Trees.Helpers (sameAssociativeOperatorAdjacent)
 import Trees.Generate (genSynTree)
 import Trees.Print (simplestDisplay)
@@ -26,7 +26,7 @@ generateSuperfluousBracketsInst SuperfluousBracketsConfig {..} = do
       { tree
       , stringWithSuperfluousBrackets
       , simplestString = simplestDisplay tree
-      , showArrowOperators = allowArrowOperators syntaxTreeConfig
+      , showArrowOperators = arrowOperatorsAllowed syntaxTreeConfig
       , showSolution = printSolution
       , addText = extraText
       , unicodeAllowed = offerUnicodeInput

--- a/src/Tasks/SuperfluousBrackets/Quiz.hs
+++ b/src/Tasks/SuperfluousBrackets/Quiz.hs
@@ -9,10 +9,12 @@ import Test.QuickCheck (Gen, suchThat)
 
 import Tasks.SuperfluousBrackets.Config (SuperfluousBracketsConfig(..), SuperfluousBracketsInst(..))
 import Tasks.SuperfluousBrackets.PrintSuperfluousBrackets (superfluousBracketsDisplay)
-import Tasks.SynTree.Config (arrowOperatorsAllowed)
+import Tasks.SynTree.Config (SynTreeConfig(binOpFrequencies))
 import Trees.Helpers (sameAssociativeOperatorAdjacent)
 import Trees.Generate (genSynTree)
 import Trees.Print (simplestDisplay)
+import Trees.Types (BinOp(..))
+import qualified Data.Map as Map (keys)
 
 
 
@@ -26,7 +28,7 @@ generateSuperfluousBracketsInst SuperfluousBracketsConfig {..} = do
       { tree
       , stringWithSuperfluousBrackets
       , simplestString = simplestDisplay tree
-      , showArrowOperators = arrowOperatorsAllowed syntaxTreeConfig
+      , showArrowOperators = any (`elem` Map.keys (binOpFrequencies syntaxTreeConfig)) [Impl, BackImpl, Equi]
       , showSolution = printSolution
       , addText = extraText
       , unicodeAllowed = offerUnicodeInput

--- a/src/Tasks/SynTree/Config.hs
+++ b/src/Tasks/SynTree/Config.hs
@@ -135,6 +135,9 @@ checkSynTreeConfig SynTreeConfig {operatorFrequencies = OperatorFrequencies{..},
     | all (== 0) operatorFrequencies = reject $ do
         english "At least one operator must have a positive frequency."
         german "Mindestens ein Operator muss eine positive Frequenz haben."
+    | minUniqueBinOperators > fromIntegral (length (filter (> 0) [and, or, impl, backImpl, equi])) = reject $ do
+        english "The minimum number of different operators exceeds the maximum number of available operators."
+        german "Die minimale Anzahl unterschiedlicher Operatoren überschreitet die maximale Anzahl an verfügbaren Operatoren."
     | otherwise = pure()
       where operatorFrequencies = [and, or, impl, backImpl, equi, neg]
 

--- a/src/Tasks/SynTree/Config.hs
+++ b/src/Tasks/SynTree/Config.hs
@@ -2,37 +2,24 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE NamedFieldPuns #-}
 
 module Tasks.SynTree.Config (
-    OperatorFrequencies(..),
     SynTreeConfig(..),
     checkSynTreeConfig,
-    defaultSynTreeConfig,
-    arrowOperatorsAllowed,
-    binOperatorFrequenciesValues
+    defaultSynTreeConfig
     ) where
 
-import Prelude hiding (and, or)
 import Control.OutputCapable.Blocks (LangM, OutputCapable, english, german)
 import Data.Char (isLetter)
 import GHC.Generics (Generic)
+import Data.Map (Map)
+import qualified Data.Map as Map (fromList, filter, keys)
 
 import LogicTasks.Helpers (reject)
 import Trees.Helpers (maxNodesForDepth, maxDepthForNodes)
 import Trees.Types (BinOp(..))
 
 import Data.List.Extra (nubOrd)
-
-data OperatorFrequencies =
-  OperatorFrequencies
-  { and :: Int
-  , or :: Int
-  , impl :: Int
-  , backImpl :: Int
-  , equi :: Int
-  , neg :: Int
-  } deriving (Show, Generic, Eq)
 
 data SynTreeConfig =
   SynTreeConfig
@@ -42,7 +29,8 @@ data SynTreeConfig =
   , maxDepth :: Integer
   , availableAtoms :: String
   , minAmountOfUniqueAtoms :: Integer
-  , operatorFrequencies :: OperatorFrequencies
+  , binOpFrequencies :: Map BinOp Int
+  , negOpFrequency :: Int
   , maxConsecutiveNegations :: Integer
   , minUniqueBinOperators :: Integer
   } deriving (Show,Generic)
@@ -58,14 +46,14 @@ defaultSynTreeConfig =
     , maxDepth = 6
     , availableAtoms = "ABCDE"
     , minAmountOfUniqueAtoms = 3
-    , operatorFrequencies = OperatorFrequencies
-      { and = 1
-      , or = 1
-      , impl = 0
-      , backImpl = 0
-      , equi = 0
-      , neg = 1
-      }
+    , binOpFrequencies = Map.fromList
+      [ (And, 1)
+      , (Or, 1)
+      , (Impl, 0)
+      , (BackImpl, 0)
+      , (Equi, 0)
+      ]
+    , negOpFrequency = 1
     , maxConsecutiveNegations = 2
     , minUniqueBinOperators = 1
     }
@@ -73,7 +61,7 @@ defaultSynTreeConfig =
 
 
 checkSynTreeConfig :: OutputCapable m => SynTreeConfig -> LangM m
-checkSynTreeConfig SynTreeConfig {operatorFrequencies = OperatorFrequencies{..},..}
+checkSynTreeConfig SynTreeConfig {..}
     | not (all isLetter availableAtoms) = reject $ do
         english "Only letters are allowed as literals."
         german "Nur Buchstaben dürfen Literale sein."
@@ -127,24 +115,22 @@ checkSynTreeConfig SynTreeConfig {operatorFrequencies = OperatorFrequencies{..},
     | minUniqueBinOperators < 0 = reject $ do
         english "There should be a non-negative number of unique operators."
         german "Es sollte eine nicht-negative Anzahl an unterschiedlichen Operatoren geben."
-    | minUniqueBinOperators > fromIntegral (length [minBound .. maxBound :: BinOp]) = reject $ do
-        english "The number of unique operators cannot exceed the maximum number of operators."
-        german "Die Anzahl der unterschiedlichen Operatoren kann nicht die maximale Anzahl überschreiten."
-    | any (< 0) operatorFrequencies = reject $ do
+    | length (Map.keys binOpFrequencies) /= length [minBound .. (maxBound :: BinOp)] = reject $ do
+        english "A frequency must be set for all operators."
+        german "Es muss für alle Operatoren eine Frequenz festgelegt sein."
+    | any (< 0) binOpFrequencies = reject $ do
         english "The operator frequencies must be non-negative."
         german "Die Frequenzen für die Operatoren müssen nicht-negativ sein."
-    | all (== 0) operatorFrequencies = reject $ do
+    | all (== 0) binOpFrequencies = reject $ do
         english "At least one operator must have a positive frequency."
         german "Mindestens ein Operator muss eine positive Frequenz haben."
-    | minUniqueBinOperators > fromIntegral (length (filter (> 0) [and, or, impl, backImpl, equi])) = reject $ do
+    | minUniqueBinOperators > fromIntegral (length (Map.filter (> 0) binOpFrequencies)) = reject $ do
         english "The minimum number of different operators exceeds the maximum number of available operators."
         german "Die minimale Anzahl unterschiedlicher Operatoren überschreitet die maximale Anzahl an verfügbaren Operatoren."
+    | negOpFrequency < 0 = reject $ do
+        english "The operator frequency for negations must be non-negative."
+        german "Die Frequenz für den Negationsoperator muss nicht-negativ sein."
+    | negOpFrequency == 0 && maxConsecutiveNegations /= 0 || maxConsecutiveNegations == 0 && negOpFrequency /= 0 = reject $ do
+        english "The maximum number of consecutive negations does not comply with the frequency of the negation operator."
+        german "Maximale Anzahl an aufeinanderfolgenden Negationen passt nicht zur Frequenz des Negationsoperators."
     | otherwise = pure()
-      where operatorFrequencies = [and, or, impl, backImpl, equi, neg]
-
-arrowOperatorsAllowed :: SynTreeConfig -> Bool
-arrowOperatorsAllowed SynTreeConfig{operatorFrequencies=OperatorFrequencies{impl,backImpl,equi}} =
-  any (> 0) [impl, backImpl, equi]
-
-binOperatorFrequenciesValues :: OperatorFrequencies -> [Int]
-binOperatorFrequenciesValues OperatorFrequencies {..} = [and, or, impl, backImpl, equi]

--- a/src/Tasks/SynTree/Config.hs
+++ b/src/Tasks/SynTree/Config.hs
@@ -9,7 +9,8 @@ module Tasks.SynTree.Config (
     SynTreeConfig(..),
     checkSynTreeConfig,
     defaultSynTreeConfig,
-    arrowOperatorsAllowed
+    arrowOperatorsAllowed,
+    binOperatorFrequenciesValues
     ) where
 
 import Prelude hiding (and, or)
@@ -144,3 +145,6 @@ checkSynTreeConfig SynTreeConfig {operatorFrequencies = OperatorFrequencies{..},
 arrowOperatorsAllowed :: SynTreeConfig -> Bool
 arrowOperatorsAllowed SynTreeConfig{operatorFrequencies=OperatorFrequencies{impl,backImpl,equi}} =
   any (> 0) [impl, backImpl, equi]
+
+binOperatorFrequenciesValues :: OperatorFrequencies -> [Int]
+binOperatorFrequenciesValues OperatorFrequencies {..} = [and, or, impl, backImpl, equi]

--- a/src/Tasks/SynTree/Config.hs
+++ b/src/Tasks/SynTree/Config.hs
@@ -31,7 +31,7 @@ data OperatorFrequencies =
   , backImpl :: Int
   , equi :: Int
   , neg :: Int
-  } deriving (Show, Generic)
+  } deriving (Show, Generic, Eq)
 
 data SynTreeConfig =
   SynTreeConfig

--- a/src/Tasks/TreeToFormula/Quiz.hs
+++ b/src/Tasks/TreeToFormula/Quiz.hs
@@ -9,8 +9,10 @@ import Trees.Generate (genSynTree)
 import Test.QuickCheck (Gen,)
 
 import Tasks.TreeToFormula.Config (TreeToFormulaConfig(..), TreeToFormulaInst(..))
-import Tasks.SynTree.Config (arrowOperatorsAllowed)
+import Tasks.SynTree.Config (SynTreeConfig(binOpFrequencies))
 import Trees.Print (transferToPicture, display)
+import Trees.Types (BinOp(..))
+import qualified Data.Map as Map (keys)
 
 
 
@@ -23,7 +25,7 @@ generateTreeToFormulaInst TreeToFormulaConfig {..} = do
       , latexImage = transferToPicture tree
       , correct = display tree
       , addExtraHintsOnSemanticEquivalence = extraHintsOnSemanticEquivalence
-      , showArrowOperators = arrowOperatorsAllowed syntaxTreeConfig
+      , showArrowOperators = any (`elem` Map.keys (binOpFrequencies syntaxTreeConfig)) [Impl, BackImpl, Equi]
       , addText = extraText
       , showSolution = printSolution
       , unicodeAllowed = offerUnicodeInput

--- a/src/Tasks/TreeToFormula/Quiz.hs
+++ b/src/Tasks/TreeToFormula/Quiz.hs
@@ -9,7 +9,7 @@ import Trees.Generate (genSynTree)
 import Test.QuickCheck (Gen,)
 
 import Tasks.TreeToFormula.Config (TreeToFormulaConfig(..), TreeToFormulaInst(..))
-import Tasks.SynTree.Config (SynTreeConfig(..))
+import Tasks.SynTree.Config (arrowOperatorsAllowed)
 import Trees.Print (transferToPicture, display)
 
 
@@ -23,7 +23,7 @@ generateTreeToFormulaInst TreeToFormulaConfig {..} = do
       , latexImage = transferToPicture tree
       , correct = display tree
       , addExtraHintsOnSemanticEquivalence = extraHintsOnSemanticEquivalence
-      , showArrowOperators = allowArrowOperators syntaxTreeConfig
+      , showArrowOperators = arrowOperatorsAllowed syntaxTreeConfig
       , addText = extraText
       , showSolution = printSolution
       , unicodeAllowed = offerUnicodeInput

--- a/src/Trees/Helpers.hs
+++ b/src/Trees/Helpers.hs
@@ -183,3 +183,4 @@ mirrorTree (Binary BackImpl l r) = Binary Impl (mirrorTree r) (mirrorTree l)
 mirrorTree (Binary b l r) = Binary b (mirrorTree r) (mirrorTree l)
 mirrorTree (Not x) = Not $ mirrorTree x
 mirrorTree x = x
+

--- a/src/Trees/Helpers.hs
+++ b/src/Trees/Helpers.hs
@@ -183,4 +183,3 @@ mirrorTree (Binary BackImpl l r) = Binary Impl (mirrorTree r) (mirrorTree l)
 mirrorTree (Binary b l r) = Binary b (mirrorTree r) (mirrorTree l)
 mirrorTree (Not x) = Not $ mirrorTree x
 mirrorTree x = x
-

--- a/test/DecomposeFormulaSpec.hs
+++ b/test/DecomposeFormulaSpec.hs
@@ -9,15 +9,16 @@ import Tasks.DecomposeFormula.Config (
   DecomposeFormulaInst(..))
 import Test.QuickCheck
 import SynTreeSpec (validBoundsSynTree)
-import Tasks.SynTree.Config (SynTreeConfig(..), OperatorFrequencies(impl, backImpl))
+import Tasks.SynTree.Config (SynTreeConfig(..))
 import Control.OutputCapable.Blocks (LangM)
 import Data.Maybe (isJust, fromJust)
 import Control.Monad.Identity (Identity(runIdentity))
 import Control.OutputCapable.Blocks.Generic (evalLangM)
 import Tasks.DecomposeFormula.Quiz (generateDecomposeFormulaInst)
 import Trees.Helpers (bothKids, binOp)
-import Trees.Types (SynTree(..))
+import Trees.Types (SynTree(..), BinOp(..))
 import Trees.Print (display)
+import qualified Data.Map as Map (fromList)
 
 validBoundsDecomposeFormula :: Gen DecomposeFormulaConfig
 validBoundsDecomposeFormula = do
@@ -25,10 +26,13 @@ validBoundsDecomposeFormula = do
     minUniqueBinOperators >= 1 && minUniqueBinOperators < 4 && minNodes > 6
   return DecomposeFormulaConfig {
     syntaxTreeConfig = syntaxTreeConfig {
-      operatorFrequencies = (operatorFrequencies syntaxTreeConfig) {
-        impl = 0,
-        backImpl = 0
-      }
+      binOpFrequencies = Map.fromList
+        [ (And, 1)
+        , (Or, 1)
+        , (Impl, 0)
+        , (BackImpl, 0)
+        , (Equi, 1)
+        ]
     },
     extraHintsOnAssociativity = False,
     extraText = Nothing,

--- a/test/DecomposeFormulaSpec.hs
+++ b/test/DecomposeFormulaSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 module DecomposeFormulaSpec where
 
@@ -10,7 +9,7 @@ import Tasks.DecomposeFormula.Config (
   DecomposeFormulaInst(..))
 import Test.QuickCheck
 import SynTreeSpec (validBoundsSynTree)
-import Tasks.SynTree.Config (SynTreeConfig(..))
+import Tasks.SynTree.Config (SynTreeConfig(..), OperatorFrequencies(impl, backImpl))
 import Control.OutputCapable.Blocks (LangM)
 import Data.Maybe (isJust, fromJust)
 import Control.Monad.Identity (Identity(runIdentity))
@@ -23,9 +22,14 @@ import Trees.Print (display)
 validBoundsDecomposeFormula :: Gen DecomposeFormulaConfig
 validBoundsDecomposeFormula = do
   syntaxTreeConfig <- validBoundsSynTree `suchThat` \SynTreeConfig{..} ->
-    minUniqueBinOperators >= 1 && minNodes > 6
+    minUniqueBinOperators >= 1 && minUniqueBinOperators < 4 && minNodes > 6
   return DecomposeFormulaConfig {
-    syntaxTreeConfig,
+    syntaxTreeConfig = syntaxTreeConfig {
+      operatorFrequencies = (operatorFrequencies syntaxTreeConfig) {
+        impl = 0,
+        backImpl = 0
+      }
+    },
     extraHintsOnAssociativity = False,
     extraText = Nothing,
     printSolution = False,

--- a/test/SynTreeSpec.hs
+++ b/test/SynTreeSpec.hs
@@ -11,7 +11,12 @@ import Data.List.Extra (nubOrd, isInfixOf)
 import TestHelpers (deleteSpaces)
 import Trees.Print (display)
 import Trees.Parsing (formulaParse)
-import Tasks.SynTree.Config (SynTreeConfig (..), OperatorFrequencies(..), checkSynTreeConfig, defaultSynTreeConfig, binOperatorFrequenciesValues)
+import Tasks.SynTree.Config (
+  SynTreeConfig (..),
+  OperatorFrequencies(..),
+  checkSynTreeConfig,
+  defaultSynTreeConfig,
+  binOperatorFrequenciesValues)
 import Trees.Helpers (
   collectLeaves,
   treeDepth,
@@ -130,7 +135,7 @@ spec = do
         \synTreeConfig@SynTreeConfig {..} -> forAll (genSynTree synTreeConfig) $ \synTree ->
             treeDepth synTree == maxDepth && treeNodes synTree == maxNodes
     it "should respect operator frequencies" $
-       forAll (validBoundsSynTree `suchThat` ((== opFrequenciesNoArrows) . operatorFrequencies)) $ \synTreeConfig@SynTreeConfig {..} ->
+       forAll (validBoundsSynTree `suchThat` ((== opFrequenciesNoArrows) . operatorFrequencies)) $ \synTreeConfig ->
         forAll (genSynTree synTreeConfig) $ \tree ->
           any  (`notElem` collectUniqueBinOpsInSynTree tree) [Impl, BackImpl, Equi]
 

--- a/test/SynTreeSpec.hs
+++ b/test/SynTreeSpec.hs
@@ -11,7 +11,7 @@ import Data.List.Extra (nubOrd, isInfixOf)
 import TestHelpers (deleteSpaces)
 import Trees.Print (display)
 import Trees.Parsing (formulaParse)
-import Tasks.SynTree.Config (SynTreeConfig (..), OperatorFrequencies(..), checkSynTreeConfig, defaultSynTreeConfig)
+import Tasks.SynTree.Config (SynTreeConfig (..), OperatorFrequencies(..), checkSynTreeConfig, defaultSynTreeConfig, binOperatorFrequenciesValues)
 import Trees.Helpers (
   collectLeaves,
   treeDepth,
@@ -63,7 +63,7 @@ validBoundsSynTree = do
   maxNodes <- choose (minNodes, maxNodesForDepth maxDepth) `suchThat`
     \maxNodes' -> (maxConsecutiveNegations /= 0 || odd maxNodes')
       && maxDepth <= maxDepthForNodes maxConsecutiveNegations maxNodes'
-  let availableBinOpsCount = if operatorFrequencies == opFrequencies then fromIntegral $ length [minBound .. maxBound :: BinOp] else 2
+  let availableBinOpsCount = fromIntegral $ length $ filter (>0) (binOperatorFrequenciesValues operatorFrequencies)
   minUniqueBinOperators <- choose (1, min availableBinOpsCount ((minNodes - 1) `div` 2))
   return $ SynTreeConfig {
     maxNodes,


### PR DESCRIPTION
Aus #137:
> Aspekte wie "LegalProposition sollte kein <= benutzen" ließen sich einbringen, indem der Config-Checker für diesen Aufgabentyp einfach nicht erlaubt, dass für BackImpl ein positiver Wert gesetzt ist.

Sollten wir das hier wirklich über den Config-Checker erzwingen?  Wenn nur 
> [...], ob das nicht bereits ein Fehler ist, da man die Implikation nur in die andere Richtung kennengelernt hat.

der Grund dafür ist, würde ich das eher vermeiden und dies lieber dem Lehrenden selbst überlassen.