### PR TITLE
Single- und Multiple Choice Anpassungen

### DIFF
--- a/src/LogicTasks/Helpers.hs
+++ b/src/LogicTasks/Helpers.hs
@@ -13,23 +13,19 @@ import Control.OutputCapable.Blocks (
   LangM,
   Language,
   OutputCapable,
-  Rated,
   english,
   german,
   translate,
   translations,
   translatedCode,
   localise,
-  recoverWith,
   )
-import Control.OutputCapable.Blocks.Generic (($>>),($>>=))
 import Control.Monad.State (State, put)
 import Data.Map (Map)
 import Data.ByteString.Lazy (fromStrict)
 import Data.ByteString.UTF8 (fromString)
 import Data.Digest.Pure.SHA (sha256, showDigest)
 import System.Directory (doesFileExist)
-import Control.Applicative (Alternative)
 
 
 
@@ -173,17 +169,3 @@ cacheIO path ext name what how = (file <$) . cache $ how file what
     whatId = path ++ name ++ showDigest (sha256 $ fromStrict what')
     whatFile = whatId ++ ".hs"
     file = whatId ++ ext
-
-{-
-Append some remarks after some rating function.
-But re-reject afterwards (if it was rejected by the rating function).
--}
-reRefuse
-  :: (Alternative m, Monad m, OutputCapable m)
-  => Rated m
-  -> LangM m
-  -> Rated m
-reRefuse xs ys =
-  recoverWith (pure 0) xs
-    $>>= \x -> ys
-    $>> either (refuse (pure ()) *>) pure x

--- a/src/LogicTasks/Semantics/Decide.hs
+++ b/src/LogicTasks/Semantics/Decide.hs
@@ -17,6 +17,7 @@ import Control.OutputCapable.Blocks (
   multipleChoice,
   translations,
   ArticleToUse (DefiniteArticle),
+  reRefuse,
   )
 import Data.List.Extra (nubOrd)
 import Test.QuickCheck (Gen, suchThat)
@@ -25,7 +26,7 @@ import Config (DecideConfig(..), DecideInst(..), FormulaConfig (..), FormulaInst
 import Formula.Table (flipAt, readEntries)
 import Formula.Types (atomics, availableLetter, getTable, literals)
 import Util (isOutside, preventWithHint, remove, printWithHint, withRatio, checkTruthValueRangeAndFormulaConf)
-import LogicTasks.Helpers (extra, reRefuse)
+import LogicTasks.Helpers (extra)
 import Control.Monad (when, unless)
 import Trees.Generate (genSynTree)
 import Trees.Formula ()

--- a/src/LogicTasks/Syntax/IllegalCnfs.hs
+++ b/src/LogicTasks/Syntax/IllegalCnfs.hs
@@ -13,6 +13,7 @@ import Control.OutputCapable.Blocks (
   multipleChoice,
   ArticleToUse (DefiniteArticle),
   translations,
+  multipleChoiceSyntax,
   )
 import Data.Map as Map (fromAscList)
 import LogicTasks.Helpers
@@ -63,14 +64,7 @@ start = []
 
 
 partialGrade :: OutputCapable m => LegalCNFInst -> [Int] -> LangM m
-partialGrade LegalCNFInst{..} sol
-    | invalidIndex = reject $ do
-      english "At least one index in the list does not exist."
-      german "Mindestens einer der Indizes existiert nicht."
-
-    | otherwise = pure ()
-  where
-    invalidIndex = any (`notElem` [1..length formulaStrings]) sol
+partialGrade LegalCNFInst{..} = multipleChoiceSyntax False [1..length formulaStrings]
 
 
 completeGrade :: OutputCapable m => LegalCNFInst -> [Int] -> Rated m

--- a/src/LogicTasks/Syntax/IllegalFormulas.hs
+++ b/src/LogicTasks/Syntax/IllegalFormulas.hs
@@ -16,10 +16,11 @@ import Control.OutputCapable.Blocks (
   multipleChoice,
   ArticleToUse (DefiniteArticle),
   translations,
+  reRefuse,
   )
 import Data.List.Extra (nubSort)
 import Data.Bifunctor (second)
-import LogicTasks.Helpers (example, extra, focus, indexed, instruct, reject, reRefuse)
+import LogicTasks.Helpers (example, extra, focus, indexed, instruct, reject)
 import Tasks.LegalProposition.Config (LegalPropositionInst(..), LegalPropositionConfig(..), checkLegalPropositionConfig)
 import Control.Monad (when)
 import Trees.Print (transferToPicture)

--- a/src/LogicTasks/Syntax/IllegalFormulas.hs
+++ b/src/LogicTasks/Syntax/IllegalFormulas.hs
@@ -17,10 +17,11 @@ import Control.OutputCapable.Blocks (
   ArticleToUse (DefiniteArticle),
   translations,
   reRefuse,
+  multipleChoiceSyntax,
   )
 import Data.List.Extra (nubSort)
 import Data.Bifunctor (second)
-import LogicTasks.Helpers (example, extra, focus, indexed, instruct, reject)
+import LogicTasks.Helpers (example, extra, focus, indexed, instruct)
 import Tasks.LegalProposition.Config (LegalPropositionInst(..), LegalPropositionConfig(..), checkLegalPropositionConfig)
 import Control.Monad (when)
 import Trees.Print (transferToPicture)
@@ -74,14 +75,7 @@ start = []
 
 
 partialGrade :: OutputCapable m => LegalPropositionInst -> [Int] -> LangM m
-partialGrade LegalPropositionInst{..} sol
-    | invalidIndex = reject $ do
-      english "At least one index in the list does not exist."
-      german "Mindestens einer der Indizes existiert nicht."
-
-    | otherwise = pure ()
-  where
-    invalidIndex = any (`notElem` [1..length pseudoFormulas]) sol
+partialGrade LegalPropositionInst{..} = multipleChoiceSyntax False [1..length pseudoFormulas]
 
 
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,6 +10,6 @@ extra-deps:
   - minisat-solver-0.1
   - latex-svg-image-0.2
   - git: https://github.com/fmidue/output-blocks.git
-    commit: f2418656472b9c32bde06ec3b916fe6d749d0290
+    commit: d596175381844ce23c01e3fbe11e6f960e243d57
     subdirs:
       - output-blocks


### PR DESCRIPTION
Closes #177 
Closes #182 
Closes #183 

Bei `Pick` könnte man noch überlegen, ob der Syntaxtest bei falschem Index auch direkt abweisen soll. Da es ursprünglich nicht so wahr, habe ich es auch erstmal so gelassen.
