### PR TITLE
Multiple Choice für `SubTreeSet`

### DIFF
--- a/src/Formula/Parsing/Delayed.hs
+++ b/src/Formula/Parsing/Delayed.hs
@@ -14,7 +14,7 @@ import Text.Parsec (ParseError, parse)
 import Text.Parsec.String (Parser)
 import ParsingHelpers (fully)
 
-import Control.OutputCapable.Blocks (LangM, Language, OutputCapable, english, german)
+import Control.OutputCapable.Blocks (LangM, LangM', Language, OutputCapable, english, german)
 import Control.Monad.State (State)
 import Data.Map (Map)
 
@@ -63,10 +63,10 @@ parseDelayedWithAndThen p messaging fallBackParser whatToDo delayedAnswer =
 
 withDelayedSucceeding ::
   OutputCapable m
-  => (a -> LangM m)
+  => (a -> LangM' m b)
   -> Parser a
   -> Delayed a
-  -> LangM m
+  -> LangM' m b
 withDelayedSucceeding whatToDo p delayedAnswer =
   case parseDelayed (fully p) delayedAnswer of
     Left err -> error $ "It should be impossible here, and yet the following ParseError was encountered: " ++ show err

--- a/src/LogicTasks/Syntax/SubTreeSet.hs
+++ b/src/LogicTasks/Syntax/SubTreeSet.hs
@@ -38,7 +38,6 @@ import Control.Monad.IO.Class (MonadIO(liftIO))
 import Data.Foldable (for_)
 import Formula.Parsing.Delayed (Delayed, withDelayed, displayParseError, withDelayedSucceeding)
 import Formula.Parsing (Parse(..))
-import GHC.Real ((%))
 import Control.Applicative (Alternative)
 
 
@@ -148,7 +147,7 @@ completeGrade'
   -> Rated m
 completeGrade' path SubTreeInst{..} sol = reRefuse
   (extendedMultipleChoice
-    (MinimumThreshold (1 % 2))
+    (MinimumThreshold 0)
     (Punishment 0)
     (TargetedCorrect (fromIntegral minInputTrees))
     IndefiniteArticle

--- a/src/LogicTasks/Syntax/SubTreeSet.hs
+++ b/src/LogicTasks/Syntax/SubTreeSet.hs
@@ -25,7 +25,8 @@ import Control.OutputCapable.Blocks (
   )
 import Data.List (nub, sort)
 import Data.Set (toList)
-import qualified Data.Map as Map (fromList)
+import qualified Data.Set (map)
+import qualified Data.Map as Map (fromSet)
 import Data.Maybe (isNothing, fromJust)
 import LogicTasks.Helpers (extra, focus, instruct, keyHeading, reject, basicOpKey, arrowsKey)
 import Tasks.SubTree.Config (checkSubTreeConfig, SubTreeInst(..), SubTreeConfig(..))
@@ -170,4 +171,4 @@ completeGrade' path SubTreeInst{..} sol = reRefuse
       what = translations $ do
         german "Teilformeln"
         english "subformulas"
-      solution = Map.fromList $ map (\t -> (display t, True)) $ Data.Set.toList correctTrees
+      solution = Map.fromSet (const True) $ Data.Set.map display correctTrees

--- a/src/LogicTasks/Syntax/SubTreeSet.hs
+++ b/src/LogicTasks/Syntax/SubTreeSet.hs
@@ -40,6 +40,7 @@ import Data.Foldable (for_)
 import Formula.Parsing.Delayed (Delayed, withDelayed, displayParseError, withDelayedSucceeding)
 import Formula.Parsing (Parse(..))
 import Control.Applicative (Alternative)
+import GHC.Real ((%))
 
 
 description :: OutputCapable m => SubTreeInst -> LangM m
@@ -51,8 +52,8 @@ description SubTreeInst{..} = do
     focus (display tree)
 
     instruct $ do
-      english $ "Find at least " ++ show minInputTrees ++ " non-atomic subformulas that are contained in it."
-      german $ "Finden Sie mindestens " ++ show minInputTrees ++ " nicht-atomare Teilformeln, die in dieser Formel enthalten sind."
+      english $ "Find " ++ show minInputTrees ++ " non-atomic subformulas that are contained in it."
+      german $ "Finden Sie " ++ show minInputTrees ++ " nicht-atomare Teilformeln, die in dieser Formel enthalten sind."
 
     instruct $ do
       english "Submit your solution as a list of subformulas."
@@ -123,6 +124,11 @@ partialGrade' SubTreeInst{..} fs
         english $ "Your solution does not contain enough subformulas. Add " ++ show (minInputTrees - amount) ++ "."
         german $ "Ihre Abgabe beinhaltet nicht genügend Teilformeln. Fügen Sie " ++ show (minInputTrees - amount) ++ " hinzu."
 
+    | amount > minInputTrees =
+      reject $ do
+        english "Your solution contains too many formulas."
+        german "Ihre Abgabe enthält zu viele Formeln."
+
     | otherwise = pure ()
   where
     amount = fromIntegral $ length $ nub fs
@@ -148,7 +154,7 @@ completeGrade'
   -> Rated m
 completeGrade' path SubTreeInst{..} sol = reRefuse
   (extendedMultipleChoice
-    (MinimumThreshold 0)
+    (MinimumThreshold (1 % minInputTrees))
     (Punishment 0)
     (TargetedCorrect (fromIntegral minInputTrees))
     IndefiniteArticle
@@ -158,8 +164,8 @@ completeGrade' path SubTreeInst{..} sol = reRefuse
     (map show sol))
   $ when showSolution $ indent $ do
     instruct $ do
-      english ("A possible solution for this task contains at least " ++ show minInputTrees ++ " of the following subformulas:")
-      german ("Eine mögliche Lösung für die Aufgabe beinhaltet mindestens " ++ show minInputTrees ++ " der folgenden Teilformeln:")
+      english ("A possible solution for this task contains " ++ show minInputTrees ++ " of the following subformulas:")
+      german ("Eine mögliche Lösung für die Aufgabe beinhaltet " ++ show minInputTrees ++ " der folgenden Teilformeln:")
 
     for_ (toList correctTrees) $ \x -> do
       code (display x)

--- a/src/LogicTasks/Syntax/SubTreeSet.hs
+++ b/src/LogicTasks/Syntax/SubTreeSet.hs
@@ -26,7 +26,7 @@ import Control.OutputCapable.Blocks (
 import Data.List (nub, sort)
 import Data.Set (toList)
 import qualified Data.Set (map)
-import qualified Data.Map as Map (fromSet)
+import qualified Data.Map as Map (fromSet, insert, filter)
 import Data.Maybe (isNothing, fromJust)
 import LogicTasks.Helpers (extra, focus, instruct, keyHeading, reject, basicOpKey, arrowsKey)
 import Tasks.SubTree.Config (checkSubTreeConfig, SubTreeInst(..), SubTreeConfig(..))
@@ -161,7 +161,7 @@ completeGrade' path SubTreeInst{..} sol = reRefuse
     what
     Nothing
     solution
-    (map show sol))
+    submission)
   $ when showSolution $ indent $ do
     instruct $ do
       english ("A possible solution for this task contains " ++ show minInputTrees ++ " of the following subformulas:")
@@ -178,3 +178,4 @@ completeGrade' path SubTreeInst{..} sol = reRefuse
         german "Teilformeln"
         english "subformulas"
       solution = Map.fromSet (const True) $ Data.Set.map display correctTrees
+      submission = foldr ((`Map.insert` True) . show) (Map.filter not solution) sol

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,6 +10,6 @@ extra-deps:
   - minisat-solver-0.1
   - latex-svg-image-0.2
   - git: https://github.com/fmidue/output-blocks.git
-    commit: d596175381844ce23c01e3fbe11e6f960e243d57
+    commit: dbc0713b6b8da7d1305bbfbd4d6856a78676e1e1
     subdirs:
       - output-blocks


### PR DESCRIPTION
Die Bewertung sieht jetzt wie folgt aus:
- Enthält die Abgabe eine syntaktisch falsche Formel, wird die Einreichung abgelehnt (in `partialGrade`)
- Enthält die Abgabe weniger als `minInputTrees` Formeln, wird die Einreichung abgelehnt  (in `partialGrade`)
- Enthält die Abgabe mindestens `minInputTrees` richtige Teilformeln, erhält der Studierende die volle Punktzahl
- Falsche Teilformeln ziehen keine Punkte ab (wenn ich das hier ändern würde, gäbe es auch für überschüssige korrekte Teilformeln Minuspunkte)