### PR TITLE
Adapt Output of Step and Resolve to consider `useSetNotation` settings 

### DIFF
--- a/src/LogicTasks/Semantics/Resolve.hs
+++ b/src/LogicTasks/Semantics/Resolve.hs
@@ -75,13 +75,13 @@ description :: OutputCapable m => Bool -> ResolutionInst -> LangM m
 description oneInput ResolutionInst{..} = do
   paragraph $ do
     translate $ do
-      german "Betrachten Sie die folgende Formel in KNF:"
-      english "Consider the following formula in cnf:"
+      german $ "Betrachten Sie die folgende " ++ gerSet ++ "Formel in KNF:"
+      english $ "Consider the following " ++ engSet ++ "formula in cnf:"
     indent $ code $ show' clauses
     pure ()
   paragraph $ translate $ do
-    german "Führen Sie das Resolutionsverfahren an dieser Formel durch, um die leere Klausel abzuleiten."
-    english "Use the resolution technique on this formula to derive the empty clause."
+    german "Führen Sie das Resolutionsverfahren an ihr durch, um die leere Klausel abzuleiten."
+    english "Use the resolution technique on it to derive the empty clause."
 
   paragraph $ translate $ if oneInput
     then do
@@ -120,8 +120,8 @@ description oneInput ResolutionInst{..} = do
     english "You can optionally replace clauses with numbers."
 
   paragraph $ translate $ do
-    german "Klauseln aus der Formel sind bereits ihrer Reihenfolge nach nummeriert. (erste Klausel = 1, zweite Klausel = 2, ...)."
-    english "Clauses in the starting formula are already numbered by their order. first clause = 1, second clause = 2, ...)."
+    german "Bestehende Klauseln sind bereits ihrer Reihenfolge nach nummeriert. (erste Klausel = 1, zweite Klausel = 2, ...)."
+    english "Existing Clauses are already numbered by their order. first clause = 1, second clause = 2, ...)."
 
   paragraph $ translate $ if oneInput
     then do
@@ -150,6 +150,13 @@ description oneInput ResolutionInst{..} = do
       show' = if usesSetNotation
         then showCnfAsSet . mkCnf
         else show . mkCnf
+
+      (gerSet,engSet)
+        | unicodeAllowed =
+          ( "Mengenschreibweise einer " -- no-spell-check
+          , "Set notation of a "
+          )
+        | otherwise = ( "", "")
 
       setExample
         | unicodeAllowed && oneInput = do

--- a/src/LogicTasks/Semantics/Resolve.hs
+++ b/src/LogicTasks/Semantics/Resolve.hs
@@ -20,7 +20,7 @@ import Control.OutputCapable.Blocks (
   yesNo,
   recoverFrom,
   )
-import Data.List (sort)
+import Data.List (intercalate, sort)
 import Data.Maybe (fromJust, fromMaybe, isNothing)
 import Test.QuickCheck (Gen)
 
@@ -369,7 +369,8 @@ completeGrade' ResolutionInst{..} sol = (if isCorrect then id else refuse) $ do
     applied = applySteps clauses steps
     stepsGraded = gradeSteps usesSetNotation steps (isNothing applied)
     isCorrect = any isEmptyClause (fromMaybe [] applied)
-    solutionDisplay = show $ map (tripShow usesSetNotation) solClauses
+    solutionDisplay =
+      '[' : intercalate ", " (map (tripShow usesSetNotation) solClauses) ++ "]"
 
 
 baseMapping :: [Clause] -> [(Int,Clause)]

--- a/src/LogicTasks/Semantics/Resolve.hs
+++ b/src/LogicTasks/Semantics/Resolve.hs
@@ -259,6 +259,11 @@ verifyQuiz ResolutionConfig{..}
           german "Diese minimale Schrittzahl kann mit den gegebenen Literalen nicht durchgeführt werden."
           english "This amount of steps is impossible with the given amount of literals."
 
+    | printFeedbackImmediately && printSolution =
+        refuse $ indent $ translate $ do
+          german "Wenn sofortiges Feedback eingeschaltet ist, kann nicht abschließend die Lösung angezeigt werden."
+          english "If instant feedback is turned on, then the correct solution cannot be given."
+
     | otherwise = checkBaseConf baseConf
 
 

--- a/src/LogicTasks/Semantics/Resolve.hs
+++ b/src/LogicTasks/Semantics/Resolve.hs
@@ -152,7 +152,7 @@ description oneInput ResolutionInst{..} = do
         else show . mkCnf
 
       (gerSet,engSet)
-        | unicodeAllowed =
+        | usesSetNotation =
           ( "Mengenschreibweise einer " -- no-spell-check
           , "Set notation of a "
           )

--- a/src/LogicTasks/Semantics/Resolve.hs
+++ b/src/LogicTasks/Semantics/Resolve.hs
@@ -419,6 +419,6 @@ replaceAll (Res (c1,c2,(c3,i)) : rest) mapping = (replaceNum c1, replaceNum c2, 
 
 tripShow :: Bool -> (Clause,Clause,Clause) -> String
 tripShow setNotation (c1,c2,c3) =
-    '(' : show' c1 ++ ',' : show' c2 ++ ',' : show' c3 ++ ")"
+    '(' : show' c1 ++ ", " ++ show' c2 ++ ", " ++ show' c3 ++ ")"
   where
     show' = showClause setNotation

--- a/src/LogicTasks/Semantics/Resolve.hs
+++ b/src/LogicTasks/Semantics/Resolve.hs
@@ -326,7 +326,7 @@ partialGrade' ResolutionInst{..} sol = do
       translate $ do
         german "Mindestens ein Schritt beinhaltet Literale, die in der Formel nicht vorkommen. "
         english "At least one step contains literals not found in the original formula. "
-      itemizeM $ map (text . show) wrongLitsSteps
+      itemizeM $ map (text . tripShow usesSetNotation) wrongLitsSteps
       pure ()
     )
 

--- a/src/LogicTasks/Semantics/Resolve.hs
+++ b/src/LogicTasks/Semantics/Resolve.hs
@@ -154,7 +154,7 @@ description oneInput ResolutionInst{..} = do
       (gerSet,engSet)
         | usesSetNotation =
           ( "Mengenschreibweise einer " -- no-spell-check
-          , "Set notation of a "
+          , "set notation of a "
           )
         | otherwise = ( "", "")
 

--- a/src/LogicTasks/Semantics/Step.hs
+++ b/src/LogicTasks/Semantics/Step.hs
@@ -252,6 +252,6 @@ genResStepClause minClauseLength maxClauseLength usedLiterals = do
 
 
 showClause :: Bool -> Clause -> String
-showClause setNotation clause = if setNotation
-        then showClauseAsSet clause
-        else show clause
+showClause setNotation
+  | setNotation = showClauseAsSet
+  | otherwise = show

--- a/src/LogicTasks/Semantics/Step.hs
+++ b/src/LogicTasks/Semantics/Step.hs
@@ -98,9 +98,8 @@ description oneInput StepInst{..} = do
   extra addText
   pure ()
     where
-      show' clause = if usesSetNotation
-        then showClauseAsSet clause
-        else show clause
+      show' = showClause usesSetNotation
+
       (gerEnd, engEnd)
         | oneInput = (" in der folgenden Tupelform an: (Literal, Resolvente)." -- no-spell-check
                      , " in the following tuple form: (literal, resolvent)."
@@ -227,9 +226,13 @@ completeGrade' StepInst{..} sol =
             pure ()
   where
     mSol = fromJust $ step sol
-    displaySolution = when showSolution $ example (show solution) $ do
+    displaySolution = when showSolution $ example solToString $ do
           english "A possible solution for this task is:"
           german "Eine mögliche Lösung für die Aufgabe ist:"
+
+    solToString =
+      let (l,cl) = solution
+      in  '(' : show l ++ ',' : showClause usesSetNotation cl ++ ")"
 
 
 genResStepClause :: Int -> Int -> [Char] -> Gen (Clause, Literal, [Literal])
@@ -246,3 +249,9 @@ genResStepClause minClauseLength maxClauseLength usedLiterals = do
     clause2 <- tryGen (genClause (minLen2,maxClauseLength-1) restLits) 100
         (all (\lit -> opposite lit `notElem` lits1) .  literals)
     pure (clause2, resolveLit, lits1)
+
+
+showClause :: Bool -> Clause -> String
+showClause setNotation clause = if setNotation
+        then showClauseAsSet clause
+        else show clause

--- a/src/LogicTasks/Semantics/Step.hs
+++ b/src/LogicTasks/Semantics/Step.hs
@@ -232,7 +232,7 @@ completeGrade' StepInst{..} sol =
 
     solToString =
       let (l,cl) = solution
-      in  '(' : show l ++ ',' : showClause usesSetNotation cl ++ ")"
+      in  '(' : show l ++ ", " ++ showClause usesSetNotation cl ++ ")"
 
 
 genResStepClause :: Int -> Int -> [Char] -> Gen (Clause, Literal, [Literal])


### PR DESCRIPTION
... and add check for specific combination of `Resolve` options