### PR TITLE
Add delayed parsing function to use in `flex-tasks` parsing

### DIFF
--- a/.github/actions/spelling/advice.md
+++ b/.github/actions/spelling/advice.md
@@ -6,7 +6,7 @@ If items relate to a ...
 
   Please add a file path to the `excludes.txt` file matching the containing file.
 
-  File paths are Perl 5 Regular Expressions - you can [test](https://www.regexplanet.com/advanced/perl/) yours before committing to verify it will match your files.
+  File paths are Perl 5 Regular Expressions - you can [test](https://www.regexplanet.com/advanced/perl) yours before committing to verify it will match your files.
 
   `^` refers to the file's path from the root of the repository, so `^README\.md$` would exclude README.md (on whichever branch you're using).
 
@@ -15,7 +15,7 @@ If items relate to a ...
   If you can write a [pattern](https://github.com/check-spelling/check-spelling/wiki/Configuration-Examples:-patterns) that would match it,
   try adding it to the `patterns.txt` file.
 
-  Patterns are Perl 5 Regular Expressions - you can [test](https://www.regexplanet.com/advanced/perl/) yours before committing to verify it will match your lines.
+  Patterns are Perl 5 Regular Expressions - you can [test](https://www.regexplanet.com/advanced/perl) yours before committing to verify it will match your lines.
 
   Note that patterns can't match multiline strings.
 

--- a/src/Formula/Parsing.hs
+++ b/src/Formula/Parsing.hs
@@ -2,7 +2,6 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Formula.Parsing (
   module Formula.Parsing.Type,
-  allSymbolParser,
   formulaSymbolParser,
   formulaListSymbolParser,
   clauseSetParser,
@@ -102,10 +101,6 @@ instance (Parse a, Parse b) => Parse (a,b) where
     tokenSymbol ","
     b <- parser
     pure (a,b)
-
-
-instance Parse a => Parse (Maybe a) where
-  parser = (tokenSymbol "Nothing" >> pure Nothing) <|> (Just <$> lexeme parser)
 
 
 instance Parse Number where
@@ -348,17 +343,11 @@ prologClauseFormulaParser = (lexeme (emptyClauseParser <|> clauseParse) <?> "Cla
 listSymbolParser :: Parser ()
 listSymbolParser = tokenSymbol "[" <|> tokenSymbol "," <|> tokenSymbol "]"
 
-maybeSymbolParser :: Parser ()
-maybeSymbolParser = tokenSymbol "Nothing"
-
 formulaSymbolParser :: Parser ()
 formulaSymbolParser = void $ many logicToken
 
 formulaListSymbolParser :: Parser ()
 formulaListSymbolParser = void $ many $ logicToken <|> listSymbolParser
-
-allSymbolParser :: Parser ()
-allSymbolParser = void $ many $ try maybeSymbolParser <|> logicToken <|> listSymbolParser
 
 
 instance Parse PrologClause where

--- a/src/Formula/Parsing/Delayed.hs
+++ b/src/Formula/Parsing/Delayed.hs
@@ -59,7 +59,12 @@ parseDelayedAbortOrProcess ::
   -> LangM' m b
 parseDelayedAbortOrProcess p messaging fallBackParser delayedAnswer whatToDo =
   case parseDelayed (fully p) delayedAnswer of
-    Left err -> reject (messaging (either Just (const Nothing) $ parseDelayedRaw (fully fallBackParser) delayedAnswer) err) $> undefined
+    Left err -> reject (
+                  messaging (either Just (const Nothing) $
+                    parseDelayedRaw (fully fallBackParser) delayedAnswer)
+                    err
+                )
+                $> undefined
     Right x  -> whatToDo x
 
 parseDelayedWithAndThen ::

--- a/src/Formula/Parsing/Delayed.hs
+++ b/src/Formula/Parsing/Delayed.hs
@@ -5,7 +5,6 @@ module Formula.Parsing.Delayed (
   withDelayed,
   displayParseError,
   withDelayedSucceeding,
-  withDelayedReportOrSucceed,
   parseDelayedWithAndThen,
   complainAboutMissingParenthesesIfNotFailingOn,
   complainAboutWrongNotation
@@ -20,13 +19,11 @@ import Control.OutputCapable.Blocks (
   LangM',
   Language,
   OutputCapable,
-  ReportT,
   english,
   german,
   )
 import Control.Monad.State (State)
 import Data.Map (Map)
-import FlexTask.Generic.Parse (parseWithOrReport)
 
 import LogicTasks.Helpers (reject)
 import Formula.Parsing.Delayed.Internal (Delayed(..))
@@ -56,21 +53,6 @@ displayParseError :: ParseError -> State (Map Language String) ()
 displayParseError err = do
   english $ show err
   german $ show err
-
-withDelayedReportOrSucceed ::
-  (Monad m, OutputCapable (ReportT o m))
-  => Parser a
-  -> (Maybe ParseError -> ParseError -> State (Map Language String) ())
-  -> Parser ()
-  -> String
-  -> LangM' (ReportT o m) a
-withDelayedReportOrSucceed p messaging fallBackParser =
-  parseWithOrReport
-    (parseDelayed (fully p))
-    (\answer -> messaging (either Just (const Nothing) $
-                    parseDelayedRaw (fully fallBackParser) answer)
-    )
-    . delayed
 
 parseDelayedWithAndThen ::
   OutputCapable m

--- a/src/Formula/Parsing/Delayed.hs
+++ b/src/Formula/Parsing/Delayed.hs
@@ -66,17 +66,19 @@ parseDelayedAbortOrProcess ::
   => Parser a
   -> (Maybe ParseError -> ParseError -> State (Map Language String) ())
   -> Parser ()
-  -> Delayed a
+  -> String
   -> (a -> LangM' (ReportT o m) b)
   -> LangM' (ReportT o m) b
-parseDelayedAbortOrProcess p messaging fallBackParser delayedAnswer whatToDo =
-  case parseDelayed (fully p) delayedAnswer of
+parseDelayedAbortOrProcess p messaging fallBackParser answerString whatToDo =
+  case parseDelayed (fully p) asDelayed of
     Left err -> toAbort (indent $ translate $
                   messaging (either Just (const Nothing) $
-                    parseDelayedRaw (fully fallBackParser) delayedAnswer)
+                    parseDelayedRaw (fully fallBackParser) asDelayed)
                     err
                 )
     Right x  -> whatToDo x
+  where
+    asDelayed = delayed answerString
 
 parseDelayedWithAndThen ::
   OutputCapable m

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,11 +10,11 @@ extra-deps:
   - minisat-solver-0.1
   - latex-svg-image-0.2
   - git: https://github.com/fmidue/output-blocks.git
-    commit: d155aa5a1978329ae5ab936a78ab6dd5f74919c2
+    commit: 77dd77fcbb8084a31c6633089605f7654af12ece
     subdirs:
       - output-blocks
   - git: https://github.com/fmidue/flex-tasks.git
-    commit: b50ab20b157f3009835da0206e4bfe8872de6f81
+    commit: 26c7fe304007e78f669519bb62ae374cc85281a9
     subdirs:
       - flex-tasks
       - flex-tasks-processing


### PR DESCRIPTION
To execute only once and receive either an error message or the result, then use this value for both syntax and semantics checks.