### PR TITLE
Dreiwertige Antworten für `Decide` (für die Basis-Variante)

### DIFF
--- a/src/Config.hs
+++ b/src/Config.hs
@@ -9,7 +9,7 @@ import GHC.Generics
 import Formula.Types
 import Formula.Util
 import Data.Map (Map)
-import Control.OutputCapable.Blocks (Language)
+import Control.OutputCapable.Blocks (Language (..))
 import Tasks.SynTree.Config (SynTreeConfig (..))
 import qualified Trees.Types as ST (BinOp(..), SynTree(..))
 import Trees.Formula ()
@@ -59,7 +59,19 @@ instance Show StepAnswer where
   show (StepAnswer (Just (b,c))) = '(' : show b ++ ',' : ' ' : show c ++ ")"
   show _ = ""
 
+data DecideChoice
+  = Correct
+  | Wrong
+  | NoAnswer
+  deriving (Show,Ord,Eq,Enum,Bounded)
 
+showChoice :: Language -> DecideChoice -> String
+showChoice German Correct = "Richtig"         -- no-spell-check
+showChoice German Wrong = "Fehlerhaft"        -- no-spell-check
+showChoice German NoAnswer = "Keine Antwort"  -- no-spell-check
+showChoice English Correct = "Correct"
+showChoice English Wrong = "Wrong"
+showChoice English NoAnswer = "No answer"
 
 data PickInst = PickInst {
                  formulas :: [FormulaInst]
@@ -351,7 +363,7 @@ dDecideConf = DecideConfig
     { formulaConfig = FormulaCnf dNormalFormConf
     , percentageOfChanged = 40
     , percentTrueEntries = Just (30,70)
-    , printSolution = False
+    , printSolution = True
     , extraText = Nothing
     }
 

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -363,7 +363,7 @@ dDecideConf = DecideConfig
     { formulaConfig = FormulaCnf dNormalFormConf
     , percentageOfChanged = 40
     , percentTrueEntries = Just (30,70)
-    , printSolution = True
+    , printSolution = False
     , extraText = Nothing
     }
 

--- a/src/Formula/Parsing.hs
+++ b/src/Formula/Parsing.hs
@@ -43,6 +43,7 @@ import UniversalParser
 import Trees.Types (SynTree, BinOp)
 import Formula.Parsing.Type (Parse(..))
 import Trees.Parsing ()
+import Control.OutputCapable.Blocks (Language (..))
 
 resStepsParser :: Parser Clause -> Parser [ResStep]
 resStepsParser parseClause = (lexeme (listParse (resStepParser parseClause)) <?> "List")
@@ -393,3 +394,21 @@ instance Parse FormulaInst where
         f <- (parser :: Parser (SynTree BinOp Char))
         tokenSymbol "}"
         pure $ InstArbitrary f
+
+instance Parse DecideChoice where
+  parser = lexeme (try parseCorrect <|> try parseWrong <|> parseNoAnswer)
+    where
+      caseInsensitiveString = between (tokenSymbol "\"") (tokenSymbol "\"") . caseInsensitive
+
+      parseCorrect = Correct <$
+          ( try (caseInsensitiveString (showChoice German Correct))
+        <|> caseInsensitiveString (showChoice English Correct)
+          )
+      parseWrong = Wrong <$
+          ( try (caseInsensitiveString (showChoice German Wrong))
+        <|> caseInsensitiveString (showChoice English Wrong)
+          )
+      parseNoAnswer = NoAnswer <$
+          ( try (caseInsensitiveString (showChoice German NoAnswer))
+        <|> caseInsensitiveString (showChoice English NoAnswer)
+          )

--- a/src/Formula/Parsing.hs
+++ b/src/Formula/Parsing.hs
@@ -43,7 +43,6 @@ import UniversalParser
 import Trees.Types (SynTree, BinOp)
 import Formula.Parsing.Type (Parse(..))
 import Trees.Parsing ()
-import Control.OutputCapable.Blocks (Language (..))
 
 resStepsParser :: Parser Clause -> Parser [ResStep]
 resStepsParser parseClause = (lexeme (listParse (resStepParser parseClause)) <?> "List")
@@ -398,17 +397,15 @@ instance Parse FormulaInst where
 instance Parse DecideChoice where
   parser = lexeme (try parseCorrect <|> try parseWrong <|> parseNoAnswer)
     where
-      caseInsensitiveString = between (tokenSymbol "\"") (tokenSymbol "\"") . caseInsensitive
-
       parseCorrect = Correct <$
-          ( try (caseInsensitiveString (showChoice German Correct))
-        <|> caseInsensitiveString (showChoice English Correct)
+          ( try (caseInsensitive "Richtig")
+        <|> caseInsensitive "Correct"
           )
       parseWrong = Wrong <$
-          ( try (caseInsensitiveString (showChoice German Wrong))
-        <|> caseInsensitiveString (showChoice English Wrong)
+          ( try (caseInsensitive "Fehlerhaft")
+        <|> caseInsensitive "Wrong"
           )
       parseNoAnswer = NoAnswer <$
-          ( try (caseInsensitiveString (showChoice German NoAnswer))
-        <|> caseInsensitiveString (showChoice English NoAnswer)
+          ( try (lexeme (caseInsensitive "Keine") <* caseInsensitive "Antwort")
+        <|> (lexeme (caseInsensitive "No") <* caseInsensitive "answer")
           )

--- a/src/Formula/Parsing.hs
+++ b/src/Formula/Parsing.hs
@@ -398,14 +398,14 @@ instance Parse DecideChoice where
   parser = lexeme (try parseCorrect <|> try parseWrong <|> parseNoAnswer)
     where
       parseCorrect = Correct <$
-          ( try (caseInsensitive "Richtig")
+          ( try (caseInsensitive "Richtig") -- no-spell-check
         <|> caseInsensitive "Correct"
           )
       parseWrong = Wrong <$
-          ( try (caseInsensitive "Fehlerhaft")
+          ( try (caseInsensitive "Fehlerhaft") -- no-spell-check
         <|> caseInsensitive "Wrong"
           )
       parseNoAnswer = NoAnswer <$
-          ( try (lexeme (caseInsensitive "Keine") <* caseInsensitive "Antwort")
+          ( try (lexeme (caseInsensitive "Keine") <* caseInsensitive "Antwort") -- no-spell-check
         <|> (lexeme (caseInsensitive "No") <* caseInsensitive "answer")
           )

--- a/src/LogicTasks/Semantics/Decide.hs
+++ b/src/LogicTasks/Semantics/Decide.hs
@@ -81,8 +81,8 @@ description withDropdowns DecideInst{..} = do
     pure ()
   paragraph $ do
     translate $ do
-      english "Decide for each table row whether the truth value in the last column is correct or incorrect."
-      german "Entscheiden Sie für jede Tabellenzeile, ob der Wahrheitswert in der letzten Spalte korrekt oder fehlerhaft ist."
+      english "Decide for each row of the truth table whether the truth value in the last column is correct or incorrect."
+      german "Entscheiden Sie für jede Tabellenzeile, ob der Wahrheitswert in der letzten Spalte der Wahrheitstafel korrekt oder fehlerhaft ist."
     indent $ code $ show (flipAt (getTable formula) changed)
     pure ()
   if withDropdowns

--- a/src/LogicTasks/Semantics/Decide.hs
+++ b/src/LogicTasks/Semantics/Decide.hs
@@ -121,8 +121,8 @@ description withDropdowns DecideInst{..} = do
           german "Das n-te Listenelement entspricht der n-ten Zeile. "
           german "Ein Lösungsversuch für eine Tabelle mit vier Zeilen könnte so aussehen: "
         translatedCode $ flip localise $ translations $ do
-          english $ intercalate ", " $ map (showChoice English) [Correct,Correct,Wrong,NoAnswer]
-          german $ intercalate ", " $ map (showChoice German) [Correct,Correct,Wrong,NoAnswer]
+          english $ show $ map (showChoice English) [Correct,Correct,Wrong,NoAnswer]
+          german $ show $ map (showChoice German) [Correct,Correct,Wrong,NoAnswer]
 
         pure ()
 

--- a/test/DecideSpec.hs
+++ b/test/DecideSpec.hs
@@ -6,8 +6,8 @@ module DecideSpec where
 import Test.Hspec
 import Test.QuickCheck (forAll, Gen, choose, suchThat, elements)
 import Control.OutputCapable.Blocks (LangM, Rated)
-import Config (dDecideConf, DecideConfig (..), DecideInst (..), FormulaConfig(..))
-import LogicTasks.Semantics.Decide (verifyQuiz, genDecideInst, verifyStatic, description, partialGrade, completeGrade)
+import Config (dDecideConf, DecideConfig (..), DecideInst (..), FormulaConfig(..), DecideChoice (..))
+import LogicTasks.Semantics.Decide (verifyQuiz, genDecideInst, verifyStatic, description, partialGrade', completeGrade')
 import Data.Maybe (fromMaybe)
 import SynTreeSpec (validBoundsSynTreeConfig)
 import Formula.Types (Table(getEntries), getTable)
@@ -63,8 +63,16 @@ spec = do
     it "should pass grading with correct answer" $
       forAll validBoundsDecideConfig $ \decideConfig@DecideConfig{..} -> do
         forAll (genDecideInst decideConfig) $ \inst ->
-          doesNotRefuse (partialGrade inst (changed inst) :: LangM Maybe) &&
-          doesNotRefuse (completeGrade inst (changed inst) :: Rated Maybe)
+          doesNotRefuse
+            (partialGrade'
+              inst
+                [ if i `elem` changed inst then Wrong else Correct
+                | i <- [1.. length $ getEntries $ getTable $ formula inst]] :: LangM Maybe) &&
+          doesNotRefuse
+            (completeGrade'
+              inst
+                [ if i `elem` changed inst then Wrong else Correct
+                | i <- [1.. length $ getEntries $ getTable $ formula inst]] :: Rated Maybe)
     it "should generate an instance with the right amount of changed entries" $
       forAll validBoundsDecideConfig $ \decideConfig@DecideConfig{..} -> do
         forAll (genDecideInst decideConfig) $ \DecideInst{..} ->

--- a/test/DecideSpec.hs
+++ b/test/DecideSpec.hs
@@ -7,7 +7,7 @@ import Test.Hspec
 import Test.QuickCheck (forAll, Gen, choose, suchThat, elements)
 import Control.OutputCapable.Blocks (LangM, Rated)
 import Config (dDecideConf, DecideConfig (..), DecideInst (..), FormulaConfig(..), DecideChoice (..))
-import LogicTasks.Semantics.Decide (verifyQuiz, genDecideInst, verifyStatic, description, partialGrade', completeGrade')
+import LogicTasks.Semantics.Decide (verifyQuiz, genDecideInst, verifyStatic, description, partialGrade, completeGrade)
 import Data.Maybe (fromMaybe)
 import SynTreeSpec (validBoundsSynTreeConfig)
 import Formula.Types (Table(getEntries), getTable)
@@ -64,12 +64,12 @@ spec = do
       forAll validBoundsDecideConfig $ \decideConfig@DecideConfig{..} -> do
         forAll (genDecideInst decideConfig) $ \inst ->
           doesNotRefuse
-            (partialGrade'
+            (partialGrade
               inst
                 [ if i `elem` changed inst then Wrong else Correct
                 | i <- [1.. length $ getEntries $ getTable $ formula inst]] :: LangM Maybe) &&
           doesNotRefuse
-            (completeGrade'
+            (completeGrade
               inst
                 [ if i `elem` changed inst then Wrong else Correct
                 | i <- [1.. length $ getEntries $ getTable $ formula inst]] :: Rated Maybe)


### PR DESCRIPTION
Closes #210

Sollte es noch eine Möglichkeit geben, die Optionen auch in kürzerer Variante einreichen zu können? Also, z. B. anstatt "Fehlerhaft" einfach nur "f".

In `completeGrade` wurden bei der Lösungsanzeige zuvor nur die Indizes der falschen Zeilen angezeigt. Die Lösung wird nun so angezeigt, wie ein Studierender es auch einreichen müsste.