### PR TITLE
Remove specialized extra options

### DIFF
--- a/examples/src/Syntax/ComposeFormula/Config.hs
+++ b/examples/src/Syntax/ComposeFormula/Config.hs
@@ -10,7 +10,7 @@ import Trees.Types (BinOp(..))
 
 import Test.Hspec
 import Util.VerifyConfig
-import Control.OutputCapable.Blocks (Language(German))
+import Control.OutputCapable.Blocks (Language(..))
 import qualified Data.Map as Map (fromList)
 import Data.Map (Map)
 
@@ -39,8 +39,10 @@ small = ComposeFormulaConfig
     , minUniqueBinOperators = 2
     }
   , treeDisplayModes = (TreeDisplay, TreeDisplay)
-  , extraHintsOnAssociativity = True
-  , extraText = Nothing
+  , extraText = Just (listToFM
+                        [ (German, "Sie dürfen bei dieser Aufgabe nicht Klammern durch Verwendung von Assoziativität weglassen.")
+                        , (English, "Do not try to use associativity in order to omit brackets in this task.")
+                        ])
   , printSolution = True
   , offerUnicodeInput = False
   }
@@ -67,7 +69,6 @@ task03 = ComposeFormulaConfig
     , minUniqueBinOperators = 2
     }
   , treeDisplayModes = (TreeDisplay, TreeDisplay)
-  , extraHintsOnAssociativity = False
   , extraText = Nothing
   , printSolution = True
   , offerUnicodeInput = True

--- a/examples/src/Syntax/ComposeFormula/Config.hs
+++ b/examples/src/Syntax/ComposeFormula/Config.hs
@@ -40,7 +40,7 @@ small = ComposeFormulaConfig
     }
   , treeDisplayModes = (TreeDisplay, TreeDisplay)
   , extraText = Just (listToFM
-                        [ (German, "Sie dürfen bei dieser Aufgabe nicht Klammern durch Verwendung von Assoziativität weglassen.")
+                        [ (German, "Sie dürfen bei dieser Aufgabe nicht Klammern durch Verwendung von Assoziativität weglassen.")  -- no-spell-check
                         , (English, "Do not try to use associativity in order to omit brackets in this task.")
                         ])
   , printSolution = True

--- a/examples/src/Syntax/DecomposeFormula/Config.hs
+++ b/examples/src/Syntax/DecomposeFormula/Config.hs
@@ -36,7 +36,7 @@ small = DecomposeFormulaConfig
     , minUniqueBinOperators = 2
     }
   , extraText = Just (listToFM
-                        [ (German, "Sie dürfen bei dieser Aufgabe nicht Klammern durch Verwendung von Assoziativität weglassen.")
+                        [ (German, "Sie dürfen bei dieser Aufgabe nicht Klammern durch Verwendung von Assoziativität weglassen.")  -- no-spell-check
                         , (English, "Do not try to use associativity in order to omit brackets in this task.")
                         ])
   , printSolution = True
@@ -65,7 +65,7 @@ task05 = DecomposeFormulaConfig
     , minUniqueBinOperators = 3
     }
   , extraText = Just (listToFM
-                        [ (German, "Sie dürfen bei dieser Aufgabe nicht Klammern durch Verwendung von Assoziativität weglassen.")
+                        [ (German, "Sie dürfen bei dieser Aufgabe nicht Klammern durch Verwendung von Assoziativität weglassen.")  -- no-spell-check
                         , (English, "Do not try to use associativity in order to omit brackets in this task.")
                         ])
   , printSolution = True

--- a/examples/src/Syntax/DecomposeFormula/Config.hs
+++ b/examples/src/Syntax/DecomposeFormula/Config.hs
@@ -8,7 +8,7 @@ import Tasks.SynTree.Config (
 import Trees.Types (BinOp(..))
 import Test.Hspec
 import Util.VerifyConfig
-import Control.OutputCapable.Blocks (Language(German))
+import Control.OutputCapable.Blocks (Language(..))
 import qualified Data.Map as Map (fromList)
 import Data.Map (Map)
 
@@ -35,8 +35,10 @@ small = DecomposeFormulaConfig
     , maxConsecutiveNegations = 2
     , minUniqueBinOperators = 2
     }
-  , extraHintsOnAssociativity = True
-  , extraText = Nothing
+  , extraText = Just (listToFM
+                        [ (German, "Sie dürfen bei dieser Aufgabe nicht Klammern durch Verwendung von Assoziativität weglassen.")
+                        , (English, "Do not try to use associativity in order to omit brackets in this task.")
+                        ])
   , printSolution = True
   , offerUnicodeInput = False
   }
@@ -62,8 +64,10 @@ task05 = DecomposeFormulaConfig
     , maxConsecutiveNegations = 2
     , minUniqueBinOperators = 3
     }
-  , extraHintsOnAssociativity = True
-  , extraText = Nothing
+  , extraText = Just (listToFM
+                        [ (German, "Sie dürfen bei dieser Aufgabe nicht Klammern durch Verwendung von Assoziativität weglassen.")
+                        , (English, "Do not try to use associativity in order to omit brackets in this task.")
+                        ])
   , printSolution = True
   , offerUnicodeInput = True
   }

--- a/examples/src/Syntax/TreeToFormula/Config.hs
+++ b/examples/src/Syntax/TreeToFormula/Config.hs
@@ -39,9 +39,9 @@ task02 = TreeToFormulaConfig
     , minUniqueBinOperators = 2
     }
   , extraText = Just (listToFM
-                        [ (German, "Es muss die exakte Formel des Syntaxbaums angegeben werden. "
-                                ++ "Andere, selbst zu dieser Formel semantisch äquivalente Formeln sind keine korrekte Lösung! "
-                                ++ "Sie dürfen bei dieser Aufgabe nicht Klammern durch Verwendung von Assoziativität weglassen.")
+                        [ (German, "Es muss die exakte Formel des Syntaxbaums angegeben werden. " -- no-spell-check
+                                ++ "Andere, selbst zu dieser Formel semantisch äquivalente Formeln sind keine korrekte Lösung! "  -- no-spell-check
+                                ++ "Sie dürfen bei dieser Aufgabe nicht Klammern durch Verwendung von Assoziativität weglassen.")  -- no-spell-check
                         , (English, "The exact formula of the syntax tree must be given. "
                                 ++ "Other formulas that are semantically equivalent to this formula are incorrect solutions! "
                                 ++ "Do not try to use associativity in order to omit brackets in this task.")
@@ -72,9 +72,9 @@ task04 =  TreeToFormulaConfig
     , minUniqueBinOperators = 2
     }
   , extraText = Just (listToFM
-                        [ (German, "Es muss die exakte Formel des Syntaxbaums angegeben werden. "
-                                ++ "Andere, selbst zu dieser Formel semantisch äquivalente Formeln sind keine korrekte Lösung! "
-                                ++ "Sie dürfen bei dieser Aufgabe nicht Klammern durch Verwendung von Assoziativität weglassen.")
+                        [ (German, "Es muss die exakte Formel des Syntaxbaums angegeben werden. "  -- no-spell-check
+                                ++ "Andere, selbst zu dieser Formel semantisch äquivalente Formeln sind keine korrekte Lösung! "  -- no-spell-check
+                                ++ "Sie dürfen bei dieser Aufgabe nicht Klammern durch Verwendung von Assoziativität weglassen.")  -- no-spell-check
                         , (English, "The exact formula of the syntax tree must be given. "
                                 ++ "Other formulas that are semantically equivalent to this formula are incorrect solutions! "
                                 ++ "Do not try to use associativity in order to omit brackets in this task.")

--- a/examples/src/Syntax/TreeToFormula/Config.hs
+++ b/examples/src/Syntax/TreeToFormula/Config.hs
@@ -10,7 +10,7 @@ import Tasks.TreeToFormula.Config (
   TreeToFormulaConfig(..),checkTreeToFormulaConfig,
   )
 import Util.VerifyConfig
-import Control.OutputCapable.Blocks (Language(German))
+import Control.OutputCapable.Blocks (Language(..))
 import qualified Data.Map as Map (fromList)
 import Data.Map (Map)
 
@@ -38,9 +38,14 @@ task02 = TreeToFormulaConfig
     , maxConsecutiveNegations = 2
     , minUniqueBinOperators = 2
     }
-  , extraHintsOnSemanticEquivalence = True
-  , extraHintsOnAssociativity = True
-  , extraText = Nothing
+  , extraText = Just (listToFM
+                        [ (German, "Es muss die exakte Formel des Syntaxbaums angegeben werden. "
+                                ++ "Andere, selbst zu dieser Formel semantisch äquivalente Formeln sind keine korrekte Lösung! "
+                                ++ "Sie dürfen bei dieser Aufgabe nicht Klammern durch Verwendung von Assoziativität weglassen.")
+                        , (English, "The exact formula of the syntax tree must be given. "
+                                ++ "Other formulas that are semantically equivalent to this formula are incorrect solutions! "
+                                ++ "Do not try to use associativity in order to omit brackets in this task.")
+                        ])
   , printSolution = True
   , offerUnicodeInput = True
   }
@@ -66,9 +71,14 @@ task04 =  TreeToFormulaConfig
     , maxConsecutiveNegations = 3
     , minUniqueBinOperators = 2
     }
-  , extraHintsOnSemanticEquivalence = True
-  , extraHintsOnAssociativity = True
-  , extraText = Nothing
+  , extraText = Just (listToFM
+                        [ (German, "Es muss die exakte Formel des Syntaxbaums angegeben werden. "
+                                ++ "Andere, selbst zu dieser Formel semantisch äquivalente Formeln sind keine korrekte Lösung! "
+                                ++ "Sie dürfen bei dieser Aufgabe nicht Klammern durch Verwendung von Assoziativität weglassen.")
+                        , (English, "The exact formula of the syntax tree must be given. "
+                                ++ "Other formulas that are semantically equivalent to this formula are incorrect solutions! "
+                                ++ "Do not try to use associativity in order to omit brackets in this task.")
+                        ])
   , printSolution = True
   , offerUnicodeInput = False
   }

--- a/src/LogicTasks/Syntax/ComposeFormula.hs
+++ b/src/LogicTasks/Syntax/ComposeFormula.hs
@@ -67,10 +67,6 @@ description inputHelp path ComposeFormulaInst{..} = do
       english "(You are allowed to add arbitrarily many additional pairs of brackets in the formulas.)"
       german "(In den Formeln dürfen Sie beliebig viele zusätzliche Klammerpaare hinzufügen.)"
 
-    when addExtraHintsOnAssociativity $ instruct $ do
-        english "Remark: Do not try to use associativity in order to omit brackets in this task."
-        german "Hinweis: Sie dürfen bei dieser Aufgabe nicht Klammern durch Verwendung von Assoziativität weglassen."
-
     keyHeading
     basicOpKey unicodeAllowed
     arrowsKey

--- a/src/LogicTasks/Syntax/DecomposeFormula.hs
+++ b/src/LogicTasks/Syntax/DecomposeFormula.hs
@@ -50,10 +50,6 @@ description DecomposeFormulaInst{..} = do
       english "(You are allowed to add arbitrarily many additional pairs of brackets in the formula.)"
       german "(In der Formel dürfen Sie beliebig viele zusätzliche Klammerpaare hinzufügen.)"
 
-    when addExtraHintsOnAssociativity $ instruct $ do
-        english "Remark: Do not try to use associativity in order to omit brackets in this task."
-        german "Hinweis: Sie dürfen bei dieser Aufgabe nicht Klammern durch Verwendung von Assoziativität weglassen."
-
     keyHeading
     basicOpKey unicodeAllowed
     arrowsKey

--- a/src/LogicTasks/Syntax/TreeToFormula.hs
+++ b/src/LogicTasks/Syntax/TreeToFormula.hs
@@ -22,7 +22,6 @@ import Image.LaTeX.Render (FormulaOptions(..), SVG, defaultEnv, imageForFormula)
 import LogicTasks.Helpers (cacheIO, extra, instruct, keyHeading, reject, example, basicOpKey, arrowsKey)
 import Tasks.SynTree.Config (checkSynTreeConfig, SynTreeConfig)
 import Trees.Types (TreeFormulaAnswer(..))
-import Formula.Util (isSemanticEqual)
 import Control.Monad (when)
 import Trees.Print (transferToPicture)
 import Tasks.TreeToFormula.Config (TreeToFormulaInst(..))
@@ -49,14 +48,6 @@ description path TreeToFormulaInst{..} = do
     instruct $ do
       english "(You are allowed to add arbitrarily many additional pairs of brackets.)"
       german "(Dabei dürfen Sie beliebig viele zusätzliche Klammerpaare hinzufügen.)"
-
-    when addExtraHintsOnSemanticEquivalence $ instruct $ do
-      english "Remark: The exact formula of the syntax tree must be given. Other formulas that are semantically equivalent to this formula are incorrect solutions!"
-      german "Hinweis: Es muss die exakte Formel des Syntaxbaums angegeben werden. Andere, selbst zu dieser Formel semantisch äquivalente Formeln sind keine korrekte Lösung!"
-
-    when addExtraHintsOnAssociativity $ instruct $ do
-      english "Remark: Do not try to use associativity in order to omit brackets in this task."
-      german "Hinweis: Sie dürfen bei dieser Aufgabe nicht Klammern durch Verwendung von Assoziativität weglassen."
 
     keyHeading
     basicOpKey unicodeAllowed
@@ -118,11 +109,6 @@ completeGrade' path inst sol
           german "Ihre Abgabe ist nicht die korrekte Lösung. Der Syntaxbaum zu Ihrer eingegebenen Formel sieht so aus:"
 
         image $=<< liftIO $ cacheTree (transferToPicture treeAnswer) path
-
-        when (addExtraHintsOnSemanticEquivalence inst && isSemanticEqual treeAnswer correctTree) $
-          instruct $ do
-            english "This syntax tree is semantically equivalent to the original one, but not identical."
-            german "Dieser Syntaxbaum ist semantisch äquivalent zum ursprünglich gegebenen, aber nicht identisch."
 
         when (showSolution inst) $
           example (correct inst) $ do

--- a/src/Tasks/ComposeFormula/Config.hs
+++ b/src/Tasks/ComposeFormula/Config.hs
@@ -28,7 +28,6 @@ data TreeDisplayMode = FormulaDisplay | TreeDisplay deriving (Show,Eq, Enum, Bou
 data ComposeFormulaConfig = ComposeFormulaConfig {
       syntaxTreeConfig :: SynTreeConfig
     , treeDisplayModes :: (TreeDisplayMode, TreeDisplayMode)
-    , extraHintsOnAssociativity :: Bool
     , extraText :: Maybe (Map Language String)
     , printSolution :: Bool
     , offerUnicodeInput :: Bool
@@ -47,7 +46,6 @@ defaultComposeFormulaConfig = ComposeFormulaConfig
         ]
       }
     , treeDisplayModes = (TreeDisplay, TreeDisplay)
-    , extraHintsOnAssociativity = True
     , extraText = Nothing
     , printSolution = False
     , offerUnicodeInput = False
@@ -76,7 +74,6 @@ data ComposeFormulaInst = ComposeFormulaInst
                , rightTree :: SynTree BinOp Char
                , leftTreeImage :: Maybe String
                , rightTreeImage :: Maybe String
-               , addExtraHintsOnAssociativity :: Bool
                , addText :: Maybe (Map Language String)
                , showSolution :: Bool
                , unicodeAllowed :: Bool

--- a/src/Tasks/ComposeFormula/Quiz.hs
+++ b/src/Tasks/ComposeFormula/Quiz.hs
@@ -30,7 +30,6 @@ generateComposeFormulaInst ComposeFormulaConfig {..} = do
       , rightTree = rightTree
       , leftTreeImage = if fst treeDisplayModes == FormulaDisplay then Nothing else Just $ transferToPicture leftTree
       , rightTreeImage = if snd treeDisplayModes == FormulaDisplay then Nothing else Just $ transferToPicture rightTree
-      , addExtraHintsOnAssociativity = extraHintsOnAssociativity
       , addText = extraText
       , showSolution = printSolution
       , unicodeAllowed = offerUnicodeInput

--- a/src/Tasks/DecomposeFormula/Config.hs
+++ b/src/Tasks/DecomposeFormula/Config.hs
@@ -20,7 +20,6 @@ import LogicTasks.Helpers (reject)
 
 data DecomposeFormulaConfig = DecomposeFormulaConfig {
       syntaxTreeConfig :: SynTreeConfig
-    , extraHintsOnAssociativity :: Bool
     , extraText :: Maybe (Map Language String)
     , printSolution :: Bool
     , offerUnicodeInput :: Bool
@@ -38,7 +37,6 @@ defaultDecomposeFormulaConfig = DecomposeFormulaConfig
         , (Equi, 1)
         ]
       }
-    , extraHintsOnAssociativity = True
     , extraText = Nothing
     , printSolution = True
     , offerUnicodeInput = False
@@ -66,7 +64,6 @@ checkAdditionalConfig DecomposeFormulaConfig {syntaxTreeConfig=SynTreeConfig {..
 
 data DecomposeFormulaInst = DecomposeFormulaInst
                { tree :: SynTree BinOp Char
-               , addExtraHintsOnAssociativity :: Bool
                , addText :: Maybe (Map Language String)
                , showSolution :: Bool
                , unicodeAllowed :: Bool

--- a/src/Tasks/DecomposeFormula/Quiz.hs
+++ b/src/Tasks/DecomposeFormula/Quiz.hs
@@ -24,7 +24,6 @@ generateDecomposeFormulaInst DecomposeFormulaConfig {..} = do
         length (nubOrd [lk, rk, mirrorTree lk, mirrorTree rk]) == 4
     return $ DecomposeFormulaInst
       { tree
-      , addExtraHintsOnAssociativity = extraHintsOnAssociativity
       , addText = extraText
       , showSolution = printSolution
       , unicodeAllowed = offerUnicodeInput

--- a/src/Tasks/TreeToFormula/Config.hs
+++ b/src/Tasks/TreeToFormula/Config.hs
@@ -18,8 +18,6 @@ import Control.OutputCapable.Blocks (LangM, Language, OutputCapable)
 
 data TreeToFormulaConfig = TreeToFormulaConfig {
       syntaxTreeConfig :: SynTreeConfig
-    , extraHintsOnSemanticEquivalence :: Bool
-    , extraHintsOnAssociativity :: Bool
     , extraText :: Maybe (Map Language String)
     , printSolution :: Bool
     , offerUnicodeInput :: Bool
@@ -29,8 +27,6 @@ data TreeToFormulaConfig = TreeToFormulaConfig {
 defaultTreeToFormulaConfig :: TreeToFormulaConfig
 defaultTreeToFormulaConfig = TreeToFormulaConfig
     { syntaxTreeConfig = defaultSynTreeConfig
-    , extraHintsOnSemanticEquivalence = True
-    , extraHintsOnAssociativity = True
     , extraText = Nothing
     , printSolution = False
     , offerUnicodeInput = False
@@ -47,8 +43,6 @@ data TreeToFormulaInst = TreeToFormulaInst {
                  tree :: SynTree BinOp Char
                , latexImage :: String
                , correct :: String
-               , addExtraHintsOnSemanticEquivalence :: Bool
-               , addExtraHintsOnAssociativity :: Bool
                , showArrowOperators :: Bool
                , addText :: Maybe (Map Language String)
                , showSolution :: Bool

--- a/src/Tasks/TreeToFormula/Quiz.hs
+++ b/src/Tasks/TreeToFormula/Quiz.hs
@@ -24,8 +24,6 @@ generateTreeToFormulaInst TreeToFormulaConfig {..} = do
       { tree
       , latexImage = transferToPicture tree
       , correct = display tree
-      , addExtraHintsOnSemanticEquivalence = extraHintsOnSemanticEquivalence
-      , addExtraHintsOnAssociativity = extraHintsOnAssociativity
       , showArrowOperators = any (`elem` Map.keys (binOpFrequencies syntaxTreeConfig)) [Impl, BackImpl, Equi]
       , addText = extraText
       , showSolution = printSolution

--- a/test/ComposeFormulaSpec.hs
+++ b/test/ComposeFormulaSpec.hs
@@ -29,7 +29,6 @@ validBoundsComposeFormulaConfig = do
   return ComposeFormulaConfig {
     syntaxTreeConfig,
     treeDisplayModes = (displayModeL, displayModeR),
-    extraHintsOnAssociativity = False,
     extraText = Nothing,
     printSolution = False,
     offerUnicodeInput = False

--- a/test/DecomposeFormulaSpec.hs
+++ b/test/DecomposeFormulaSpec.hs
@@ -35,7 +35,6 @@ validBoundsDecomposeFormulaConfig = do
         , (Equi, 1)
         ]
     },
-    extraHintsOnAssociativity = False,
     extraText = Nothing,
     printSolution = False,
     offerUnicodeInput = False

--- a/test/TreeToFormulaSpec.hs
+++ b/test/TreeToFormulaSpec.hs
@@ -18,8 +18,6 @@ validBoundsTreeToFormulaConfig = do
   syntaxTreeConfig <- validBoundsSynTreeConfig
   pure $ TreeToFormulaConfig
     { syntaxTreeConfig
-    , extraHintsOnSemanticEquivalence = True
-    , extraHintsOnAssociativity = True
     , extraText = Nothing
     , printSolution = False
     , offerUnicodeInput = False


### PR DESCRIPTION
Closes #256 

Note that this also removes the check/hint on semantically equivalent formulas at `TreeToFormula` (during `completeGrade'`).