### PR TITLE
remove tryGen

### DIFF
--- a/src/LogicTasks/Semantics/Fill.hs
+++ b/src/LogicTasks/Semantics/Fill.hs
@@ -33,7 +33,6 @@ import Util (
   preventWithHint,
   remove,
   withRatio,
-  tryGen,
   checkTruthValueRangeAndFormulaConf,
   formulaDependsOnAllAtoms
   )
@@ -55,9 +54,9 @@ genFillInst FillConfig{..} = do
       (FormulaArbitrary syntaxTreeConfig) ->
         InstArbitrary <$> genSynTree syntaxTreeConfig `suchThat` withRatio percentTrueEntries'
       (FormulaCnf cnfCfg) ->
-        tryGen (InstCnf <$> genCnf' cnfCfg) 100 $ withRatio percentTrueEntries'
+        InstCnf <$> genCnf' cnfCfg `suchThat` withRatio percentTrueEntries'
       (FormulaDnf dnfCfg) ->
-        tryGen (InstDnf <$> genDnf' dnfCfg) 100 $ withRatio percentTrueEntries'
+        InstDnf <$> genDnf' dnfCfg `suchThat` withRatio percentTrueEntries'
 
     let
       entries = readEntries $ getTable formula

--- a/src/LogicTasks/Semantics/Max.hs
+++ b/src/LogicTasks/Semantics/Max.hs
@@ -18,14 +18,14 @@ import Control.OutputCapable.Blocks (
   )
 import Data.List ((\\))
 import Data.Maybe (fromMaybe)
-import Test.QuickCheck (Gen)
+import Test.QuickCheck (Gen, suchThat)
 
 import Config (BaseConfig(..), NormalFormConfig(..),  MaxInst(..), MinMaxConfig(..))
 import Formula.Util (hasEmptyClause, isEmptyCnf, mkClause, mkCnf)
 import Formula.Table (readEntries)
 import Formula.Types (Cnf, Formula, Literal(..), amount, atomics, genCnf, getClauses, getTable)
 import LogicTasks.Helpers (formulaKey, example, extra)
-import Util (checkTruthValueRange, pairwiseCheck, prevent, preventWithHint, tryGen, withRatio, checkNormalFormConfig)
+import Util (checkTruthValueRange, pairwiseCheck, prevent, preventWithHint, withRatio, checkNormalFormConfig)
 import Control.Monad (when)
 import Formula.Parsing.Delayed (Delayed, withDelayed, displayParseError, withDelayedSucceeding)
 import Formula.Parsing (Parse(..))
@@ -43,7 +43,7 @@ genMaxInst MinMaxConfig {normalFormConf = NormalFormConfig {baseConf = BaseConfi
     }
   where
     getCnf = genCnf (minClauseAmount, maxClauseAmount) (minClauseLength, maxClauseLength) usedAtoms True
-    cnfInRange = tryGen getCnf 100 $ withRatio $ fromMaybe (0,100) percentTrueEntries
+    cnfInRange = getCnf `suchThat` withRatio (fromMaybe (0,100) percentTrueEntries)
 
 
 

--- a/src/LogicTasks/Semantics/Min.hs
+++ b/src/LogicTasks/Semantics/Min.hs
@@ -19,13 +19,13 @@ import Control.OutputCapable.Blocks (
   localise,
   )
 import Data.Maybe (fromMaybe)
-import Test.QuickCheck (Gen)
+import Test.QuickCheck (Gen, suchThat)
 
 import Config (BaseConfig(..), NormalFormConfig(..), MinMaxConfig(..), MinInst(..))
 import Formula.Types (Dnf, Literal(..), amount, atomics, genDnf, getConjunctions, getTable)
 import Formula.Util (mkCon, mkDnf, hasEmptyCon, isEmptyDnf)
 import LogicTasks.Helpers (extra, formulaKey)
-import Util (tryGen, withRatio)
+import Util (withRatio)
 import Formula.Parsing.Delayed (Delayed, withDelayed, displayParseError, withDelayedSucceeding)
 import Formula.Parsing (Parse(..))
 
@@ -42,7 +42,7 @@ genMinInst MinMaxConfig {normalFormConf = NormalFormConfig {baseConf = BaseConfi
     }
    where
      getDnf = genDnf (minClauseAmount, maxClauseAmount) (minClauseLength, maxClauseLength) usedAtoms True
-     dnfInRange = tryGen getDnf 100 $ withRatio $ fromMaybe (0,100) percentTrueEntries
+     dnfInRange = getDnf `suchThat` withRatio (fromMaybe (0,100) percentTrueEntries)
 
 
 

--- a/src/LogicTasks/Semantics/Step.hs
+++ b/src/LogicTasks/Semantics/Step.hs
@@ -16,14 +16,14 @@ import Control.OutputCapable.Blocks (
 import Data.Maybe (fromJust, isNothing)
 import Data.List (delete)
 import Data.Set (difference, fromList, member, toList, union)
-import Test.QuickCheck (Gen, elements)
+import Test.QuickCheck (Gen, elements, suchThat)
 
 import Config (StepAnswer(..), StepConfig(..), StepInst(..), BaseConfig(..))
 import Formula.Util (isEmptyClause, mkClause)
 import Formula.Types (Clause, Literal(..), genClause, literals, opposite)
 import Formula.Resolution (resolvable, resolve)
 import LogicTasks.Helpers (example, extra, keyHeading, negationKey, orKey)
-import Util (checkBaseConf, prevent, preventWithHint, tryGen)
+import Util (checkBaseConf, prevent, preventWithHint)
 import Control.Monad (when, unless)
 import Formula.Parsing.Delayed (Delayed, withDelayed, complainAboutWrongNotation, withDelayedSucceeding)
 import Formula.Parsing (clauseFormulaParser, stepAnswerParser, clauseSetParser)
@@ -246,7 +246,7 @@ genResStepClause minClauseLength maxClauseLength usedAtoms = do
     clause1 <- genClause (minLen1,maxClauseLength-1) restAtoms
     let
       lits1 = literals clause1
-    clause2 <- tryGen (genClause (minLen2,maxClauseLength-1) restAtoms) 100
+    clause2 <- genClause (minLen2,maxClauseLength-1) restAtoms `suchThat`
         (all (\lit -> opposite lit `notElem` lits1) .  literals)
     pure (clause2, resolveLit, lits1)
 

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -14,7 +14,6 @@ import Control.OutputCapable.Blocks (
   translate,
   yesNo,
   )
-import Control.Monad.State (put, get, lift, evalStateT)
 import Control.Monad (when)
 import Data.List (delete)
 import Test.QuickCheck(Gen, elements, suchThat)
@@ -79,21 +78,6 @@ withRatio (lower,upper) form =
     percentage num = length tableEntries *num `div` 100
     upperBound = percentage upper
     lowerBound = percentage lower
-
-
-
-tryGen :: Gen a -> Int -> (a -> Bool) -> Gen a
-tryGen gen n b = evalStateT state 0
-  where
-    state = do
-       runs <- get
-       if runs > n
-         then error "Maximum amount of tries exceeded by generator!"
-         else do
-           res <- lift gen
-           if b res then pure res
-                    else do put (runs +1)
-                            state
 
 
 

--- a/test/MinMaxSpec.hs
+++ b/test/MinMaxSpec.hs
@@ -1,13 +1,49 @@
+{-# language DuplicateRecordFields #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
 module MinMaxSpec where
 
 import Test.Hspec (Spec, describe, it, xit)
 import Control.OutputCapable.Blocks (LangM)
-import TestHelpers (doesNotRefuse)
-import Test.QuickCheck (forAll)
+import Test.QuickCheck (Gen, chooseAny, forAll)
 import qualified LogicTasks.Semantics.Max as Max (verifyQuiz, verifyStatic, genMaxInst, description, partialGrade', completeGrade')
 import qualified LogicTasks.Semantics.Min as Min (verifyQuiz, verifyStatic, genMinInst, description, partialGrade', completeGrade')
-import Config (dMinMaxConf, MaxInst (cnf), MinInst (dnf))
+import Config (
+  BaseConfig(..),
+  NormalFormConfig(..),
+  MinMaxConfig(..),
+  dMinMaxConf,
+  MaxInst (cnf),
+  MinInst (dnf),
+  )
 
+import FormulaSpec (validBoundsNormalFormParams)
+import TestHelpers (doesNotRefuse)
+
+
+
+validBoundsMinMaxConfig :: Gen MinMaxConfig
+validBoundsMinMaxConfig = do
+  ((minClauseAmount,maxClauseAmount),(minClauseLength,maxClauseLength),usedAtoms) <- validBoundsNormalFormParams
+  offerUnicodeInput <- chooseAny
+  printSolution <- chooseAny
+  pure $ MinMaxConfig
+    { normalFormConf = NormalFormConfig{
+          minClauseAmount,
+          maxClauseAmount,
+          baseConf = BaseConfig{
+              minClauseLength,
+              maxClauseLength,
+              usedAtoms
+          }
+      }
+    -- Restrictions on this lead to infinite loops.
+    -- A satisfying formula is frequently not found, even with large intervals.
+    , percentTrueEntries = Nothing
+    , printSolution
+    , extraText = Nothing
+    , offerUnicodeInput
+    }
 
 
 spec :: Spec
@@ -16,22 +52,30 @@ spec = do
     it "default config should pass config check" $
       doesNotRefuse (Max.verifyQuiz dMinMaxConf :: LangM Maybe) &&
       doesNotRefuse (Min.verifyQuiz dMinMaxConf :: LangM Maybe)
+    it "validBoundsMinMaxConfig should generate a valid config" $
+      forAll validBoundsMinMaxConfig $ \minMaxConfigConfig ->
+        doesNotRefuse (Max.verifyQuiz minMaxConfigConfig :: LangM Maybe) &&
+        doesNotRefuse (Min.verifyQuiz minMaxConfigConfig :: LangM Maybe)
   describe "description" $ do
     it "should not reject - Max" $
-      forAll (Max.genMaxInst dMinMaxConf) $ \inst ->
-        doesNotRefuse (Max.description inst :: LangM Maybe)
+      forAll validBoundsMinMaxConfig $ \config ->
+        forAll (Max.genMaxInst config) $ \inst ->
+          doesNotRefuse (Max.description inst :: LangM Maybe)
     it "should not reject - Min" $
-      forAll (Min.genMinInst dMinMaxConf) $ \inst ->
-        doesNotRefuse (Min.description inst :: LangM Maybe)
+      forAll validBoundsMinMaxConfig $ \config ->
+        forAll (Min.genMinInst config) $ \inst ->
+          doesNotRefuse (Min.description inst :: LangM Maybe)
   describe "generateInst" $ do
     it "should pass verifyStatic - Max" $
-      forAll (Max.genMaxInst dMinMaxConf) $ \inst ->
-        doesNotRefuse
-          (Max.verifyStatic inst :: LangM Maybe)
+      forAll validBoundsMinMaxConfig $ \config ->
+        forAll (Max.genMaxInst config) $ \inst ->
+          doesNotRefuse
+            (Max.verifyStatic inst :: LangM Maybe)
     it "should pass verifyStatic - Min" $
-      forAll (Min.genMinInst dMinMaxConf) $ \inst ->
-        doesNotRefuse
-          (Min.verifyStatic inst :: LangM Maybe)
+      forAll validBoundsMinMaxConfig $ \config ->
+        forAll (Min.genMinInst config) $ \inst ->
+          doesNotRefuse
+            (Min.verifyStatic inst :: LangM Maybe)
     xit "possible solution passes partialGrade - Max" $
       forAll (Max.genMaxInst dMinMaxConf) $ \inst ->
         doesNotRefuse


### PR DESCRIPTION
closes #106 

Tasks still work as before when replacing it with `suchThat`. Also added random config testing to `MinMaxSpec` (where tests are not disabled due to "wrong" solutions being safed in the instance)