### PR TITLE
Verhältnis positiver und negativer Literale bei Formelgenerierung steuern lassen

### DIFF
--- a/examples/src/Semantics/TruthTables/ChooseForFormula/Config.hs
+++ b/examples/src/Semantics/TruthTables/ChooseForFormula/Config.hs
@@ -22,6 +22,7 @@ task08 = PickConfig
                     }
                   , minClauseAmount = 2
                   , maxClauseAmount = 2
+                  , negLiteralRatio = 2
                   })
   , amountOfOptions = 3
   , percentTrueEntries = Nothing
@@ -41,6 +42,7 @@ task11 = PickConfig
                      }
                    , minClauseAmount = 4
                    , maxClauseAmount = 4
+                   , negLiteralRatio = 2
                    })
   , amountOfOptions = 4
   , percentTrueEntries = Just (30,70)

--- a/examples/src/Semantics/TruthTables/FillGaps/Config.hs
+++ b/examples/src/Semantics/TruthTables/FillGaps/Config.hs
@@ -21,6 +21,7 @@ task07 = FillConfig
                     }
                   , minClauseAmount = 3
                   , maxClauseAmount = 3
+                  , negLiteralRatio = 2
                   })
   , percentageOfGaps = 60
   , percentTrueEntries = Just (30, 70)
@@ -40,6 +41,7 @@ task20 = FillConfig
                      }
                    , minClauseAmount = 4
                    , maxClauseAmount = 4
+                   , negLiteralRatio = 2
                    })
   , percentageOfGaps = 40
   , percentTrueEntries = Just (35, 65)

--- a/examples/src/Semantics/TruthTables/FindMistakes/Config.hs
+++ b/examples/src/Semantics/TruthTables/FindMistakes/Config.hs
@@ -30,6 +30,7 @@ task10 = DecideConfig
                      }
                    , minClauseAmount = 3
                    , maxClauseAmount = 3
+                   , negLiteralRatio = 2
                    })
   , percentageOfChanged = 40
   , percentTrueEntries = Just (30,70)

--- a/examples/src/Semantics/TruthTables/MaxTerm/Config.hs
+++ b/examples/src/Semantics/TruthTables/MaxTerm/Config.hs
@@ -22,6 +22,7 @@ unused01 = MinMaxConfig
       }
     , minClauseAmount = 3
     , maxClauseAmount = 3
+    , negLiteralRatio = 2
     }
   , percentTrueEntries = Just (50, 70)
   , extraText = Nothing
@@ -41,6 +42,7 @@ unused02 = MinMaxConfig
       }
     , minClauseAmount = 3
     , maxClauseAmount = 4
+    , negLiteralRatio = 2
     }
   , percentTrueEntries = Just (50, 70)
   , extraText = Nothing

--- a/examples/src/Semantics/TruthTables/MinTerm/Config.hs
+++ b/examples/src/Semantics/TruthTables/MinTerm/Config.hs
@@ -22,6 +22,7 @@ unused03 = MinMaxConfig
       }
     , minClauseAmount = 2
     , maxClauseAmount = 3
+    , negLiteralRatio = 2
     }
   , percentTrueEntries = Just (55, 70)
   , extraText = Nothing

--- a/examples/src/Syntax/InvalidNormalForms/Config.hs
+++ b/examples/src/Syntax/InvalidNormalForms/Config.hs
@@ -19,6 +19,7 @@ task08 = LegalNormalFormConfig
       { minClauseLength = 2, maxClauseLength = 4, usedAtoms = "ABCD" }
     , minClauseAmount = 2
     , maxClauseAmount = 4
+    , negLiteralRatio = 2
     }
   , formulas = 8
   , illegals = 4
@@ -39,6 +40,7 @@ task09 = LegalNormalFormConfig
       { minClauseLength = 2, maxClauseLength = 4, usedAtoms = "ABCD" }
     , minClauseAmount = 2
     , maxClauseAmount = 4
+    , negLiteralRatio = 2
     }
   , formulas = 8
   , illegals = 3
@@ -59,6 +61,7 @@ task18 = LegalNormalFormConfig
       { minClauseLength = 2, maxClauseLength = 4, usedAtoms = "ABCD" }
     , minClauseAmount = 2
     , maxClauseAmount = 5
+    , negLiteralRatio = 2
     }
   , formulas = 8
   , illegals = 2

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -265,6 +265,7 @@ data NormalFormConfig = NormalFormConfig
     { baseConf:: BaseConfig
     , minClauseAmount :: Int
     , maxClauseAmount :: Int
+    , negLiteralRatio :: Rational -- between 0 and 1; otherwise, it will be ignored.
     } deriving (Typeable, Generic, Show)
 
 dNormalFormConf :: NormalFormConfig
@@ -272,6 +273,7 @@ dNormalFormConf = NormalFormConfig
     { baseConf = dBaseConf
     , minClauseAmount = 2
     , maxClauseAmount = 4
+    , negLiteralRatio = 2
     }
 
 

--- a/src/Formula/Types.hs
+++ b/src/Formula/Types.hs
@@ -290,7 +290,7 @@ genCnfWithRatio :: Rational -> Rational -> (Int,Int) -> (Int,Int) -> [Char] -> B
 genCnfWithRatio negLiteralRatio negLiteralSpread (minNum,maxNum) (minLen,maxLen) atoms enforceUsingAllLiterals = do
     (num, nAtoms) <- genForNF (minNum,maxNum) (minLen,maxLen) atoms
     cnf <- generateClauses nAtoms empty num
-      `suchThat` \xs -> (not enforceUsingAllLiterals || all (`elem` concatMap atomics (Set.toList xs)) nAtoms) 
+      `suchThat` \xs -> (not enforceUsingAllLiterals || all (`elem` concatMap atomics (Set.toList xs)) nAtoms)
       && checkNegLiteralRatio xs negLiteralRatio negLiteralSpread
     pure (Cnf cnf)
   where

--- a/src/Formula/Types.hs
+++ b/src/Formula/Types.hs
@@ -290,7 +290,8 @@ genCnfWithRatio :: Rational -> Rational -> (Int,Int) -> (Int,Int) -> [Char] -> B
 genCnfWithRatio negLiteralRatio negLiteralSpread (minNum,maxNum) (minLen,maxLen) atoms enforceUsingAllLiterals = do
     (num, nAtoms) <- genForNF (minNum,maxNum) (minLen,maxLen) atoms
     cnf <- generateClauses nAtoms empty num
-      `suchThat` \xs -> (not enforceUsingAllLiterals || all (`elem` concatMap atomics (Set.toList xs)) nAtoms) && checkNegLiteralRatio xs negLiteralRatio negLiteralSpread
+      `suchThat` \xs -> (not enforceUsingAllLiterals || all (`elem` concatMap atomics (Set.toList xs)) nAtoms) 
+      && checkNegLiteralRatio xs negLiteralRatio negLiteralSpread
     pure (Cnf cnf)
   where
     generateClauses :: [Char] -> Set Clause -> Int -> Gen (Set Clause)
@@ -444,7 +445,8 @@ genDnfWithRatio :: Rational -> Rational -> (Int,Int) -> (Int,Int) -> [Char] -> B
 genDnfWithRatio negLiteralRatio negLiteralSpread (minNum,maxNum) (minLen,maxLen) atoms enforceUsingAllLiterals = do
     (num, nAtoms) <- genForNF (minNum,maxNum) (minLen,maxLen) atoms
     dnf <- generateCons nAtoms empty num
-      `suchThat` \xs -> (not enforceUsingAllLiterals || all (`elem` concatMap atomics (Set.toList xs)) nAtoms) && checkNegLiteralRatio xs negLiteralRatio negLiteralSpread
+      `suchThat` \xs -> (not enforceUsingAllLiterals || all (`elem` concatMap atomics (Set.toList xs)) nAtoms)
+      && checkNegLiteralRatio xs negLiteralRatio negLiteralSpread
     pure (Dnf dnf)
   where
     generateCons :: [Char] -> Set Con -> Int -> Gen (Set Con)

--- a/src/Formula/Types.hs
+++ b/src/Formula/Types.hs
@@ -51,7 +51,7 @@ import GHC.Generics
 import Test.QuickCheck hiding (Positive,Negative)
 import Numeric.SpecFunctions as Math (choose)
 
-import GHC.Real ((%),Rational)
+import GHC.Real ((%))
 
 newtype ResStep = Res {trip :: (Either Clause Int, Either Clause Int, (Clause, Maybe Int))} deriving Show
 
@@ -462,8 +462,6 @@ literalRatio' = Set.foldr countContainer (0, 0)
 
     countLiteral (Positive _) (neg, pos) = (neg, pos + 1)
     countLiteral (Negative _) (neg, pos) = (neg + 1, pos)
-
-test_dnf = (Set.fromList [Con (Set.fromList [Negative ('A'),Negative ('B')]),Con (Set.fromList [Negative ('C'),Negative ('B')])])
 
 literalRatio :: (Ord a, HasLiterals a) => Set a -> Rational
 literalRatio set = let (neg,pos) = literalRatio' set in (neg % (pos + neg))

--- a/src/Formula/Types.hs
+++ b/src/Formula/Types.hs
@@ -483,7 +483,7 @@ checkNegLiteralRatio set desiredRatio
   | desiredRatio < 0 || desiredRatio > 1 = True
   | snappedRatio == actualRatio = True
   | otherwise = False
-  where 
+  where
     (neg, pos) = literalRatio set
     n = pos + neg
     actualRatio = neg % n

--- a/src/LogicTasks/Util.hs
+++ b/src/LogicTasks/Util.hs
@@ -19,11 +19,11 @@ import Formula.Util (isEmptyCnf, hasEmptyClause, isEmptyDnf, hasEmptyCon)
 
 genCnf' :: NormalFormConfig -> Gen Cnf
 genCnf' (NormalFormConfig{baseConf = BaseConfig{..}, ..})
-  = genCnfWithRatio 0.5 0.5 (minClauseAmount,maxClauseAmount) (minClauseLength, maxClauseLength) usedAtoms True
+  = genCnfWithRatio negLiteralRatio (minClauseAmount,maxClauseAmount) (minClauseLength, maxClauseLength) usedAtoms True
 
 genDnf' :: NormalFormConfig -> Gen Dnf
 genDnf' (NormalFormConfig{baseConf = BaseConfig{..}, ..})
-  = genDnfWithRatio 0.5 0.5 (minClauseAmount,maxClauseAmount) (minClauseLength, maxClauseLength) usedAtoms True
+  = genDnfWithRatio negLiteralRatio (minClauseAmount,maxClauseAmount) (minClauseLength, maxClauseLength) usedAtoms True
 
 displayFormula :: FormulaInst -> String
 displayFormula (InstCnf c) = show c

--- a/src/LogicTasks/Util.hs
+++ b/src/LogicTasks/Util.hs
@@ -11,7 +11,7 @@ module LogicTasks.Util
 
 import Util
 import Test.QuickCheck (Gen)
-import Formula.Types (Cnf, genCnf, genDnf, Dnf)
+import Formula.Types (Cnf, genCnfWithRatio, genDnfWithRatio, Dnf)
 import Config (NormalFormConfig (..), BaseConfig(..), FormulaInst (..), FormulaConfig (..))
 import Trees.Print (simplestDisplay)
 import Tasks.SynTree.Config (SynTreeConfig(minAmountOfUniqueAtoms, availableAtoms))
@@ -19,11 +19,11 @@ import Formula.Util (isEmptyCnf, hasEmptyClause, isEmptyDnf, hasEmptyCon)
 
 genCnf' :: NormalFormConfig -> Gen Cnf
 genCnf' (NormalFormConfig{baseConf = BaseConfig{..}, ..})
-  = genCnf (minClauseAmount,maxClauseAmount) (minClauseLength, maxClauseLength) usedAtoms True
+  = genCnfWithRatio 0.5 0.5 (minClauseAmount,maxClauseAmount) (minClauseLength, maxClauseLength) usedAtoms True
 
 genDnf' :: NormalFormConfig -> Gen Dnf
 genDnf' (NormalFormConfig{baseConf = BaseConfig{..}, ..})
-  = genDnf (minClauseAmount,maxClauseAmount) (minClauseLength, maxClauseLength) usedAtoms True
+  = genDnfWithRatio 0.5 0.5 (minClauseAmount,maxClauseAmount) (minClauseLength, maxClauseLength) usedAtoms True
 
 displayFormula :: FormulaInst -> String
 displayFormula (InstCnf c) = show c

--- a/test/FillSpec.hs
+++ b/test/FillSpec.hs
@@ -41,6 +41,7 @@ validBoundsNormalFormConfig :: Gen NormalFormConfig
 validBoundsNormalFormConfig = do
   minClauseAmount <- choose (1, 5)
   maxClauseAmount <- choose (2, 10) `suchThat` \x -> minClauseAmount <= x
+  negLiteralRatio <- toRational <$> choose (0.0, 1.1 :: Double)
   baseConf <- validBoundsBaseConfig `suchThat` \bc ->
     minClauseAmount * minClauseLength bc >= length (usedAtoms bc) &&
     minClauseAmount <= 2 ^ length (usedAtoms bc) &&
@@ -49,6 +50,7 @@ validBoundsNormalFormConfig = do
     baseConf
   , minClauseAmount
   , maxClauseAmount
+  , negLiteralRatio
   }
 
 validBoundsFillConfig :: Gen FillConfig

--- a/test/FormulaSpec.hs
+++ b/test/FormulaSpec.hs
@@ -44,7 +44,7 @@ spec = do
   describe "genValidBoundsNormalFormParams" $
     it "should generate valid bounds" $
       withMaxSuccess 1000 $ forAll validBoundsNormalFormParams $ \((l1,u1),(l2,u2),cs) ->
-        ioProperty $ checkConfigWith German (NormalFormConfig (BaseConfig l2 u2 cs) l1 u1) checkNormalFormConfig
+        ioProperty $ checkConfigWith German (NormalFormConfig (BaseConfig l2 u2 cs) l1 u1 2) checkNormalFormConfig
 
   describe "genLiteral" $ do
     it "should throw an error when called with the empty list" $

--- a/test/LegalNormalFormSpec.hs
+++ b/test/LegalNormalFormSpec.hs
@@ -57,7 +57,8 @@ validBoundsLegalNormalFormConfig = do
                 minClauseLength,
                 maxClauseLength,
                 usedAtoms
-            }
+            },
+            negLiteralRatio = 2
           },
           formulas,
           illegals,
@@ -91,7 +92,8 @@ invalidBoundsLegalCNF = do
                 minClauseLength,
                 maxClauseLength,
                 usedAtoms
-            }
+            },
+            negLiteralRatio = 2
           },
           formulas,
           illegals,

--- a/test/MinMaxSpec.hs
+++ b/test/MinMaxSpec.hs
@@ -35,7 +35,8 @@ validBoundsMinMaxConfig = do
               minClauseLength,
               maxClauseLength,
               usedAtoms
-          }
+          },
+          negLiteralRatio = 2
       }
     -- Restrictions on this lead to infinite loops.
     -- A satisfying formula is frequently not found, even with large intervals.


### PR DESCRIPTION
CLOSE #219

Neues Feld negLiteralRatio in NormalFormConfig steuert den prozentualen Anteil der negativen Literale in der Formel.

Neue Funktionen:
- genCnfWithRatio
- genDnfWithRatio

Bereits integriert in genCnf' und genDnf'.

Der angegebene Anteil wird an den nächstmöglichen Anteil angenähert, damit immer eine Formel generiert werden kann, die die Bedingung erfüllt. Beispielsweise eine Formel mit 9 Literalen und einem gewünschten Anteil von 30 % wird auf 1/3 (≈ 33  %) geprüft.

Ist der angegebene Anteil außerhalb des Intervalls [0, 1], wird eine zufällige Formel generiert.