### PR TITLE
remove 'derive Typeable'

### DIFF
--- a/src/Config.hs
+++ b/src/Config.hs
@@ -1,18 +1,11 @@
-{-# LANGUAGE CPP #-}
 {-# language DeriveDataTypeable #-}
 {-# language DeriveGeneric #-}
-#if !MIN_VERSION_base(4,18,0)
-{-# LANGUAGE DerivingStrategies #-}
-#endif
 {-# language DuplicateRecordFields #-}
 
 module Config where
 
 
 import Data.Data (Data)
-#if !MIN_VERSION_base(4,18,0)
-import Data.Typeable (Typeable)
-#endif
 import GHC.Generics
 import Formula.Types
 import Formula.Util
@@ -60,16 +53,10 @@ instance ToSAT FormulaInst where
 
 newtype Number = Number {value :: Maybe Int}
   deriving (Generic, Show)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 
 newtype StepAnswer = StepAnswer {step :: Maybe (Literal, Clause)}
   deriving Generic
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 instance Show StepAnswer where
   show (StepAnswer (Just (b,c))) = '(' : show b ++ ',' : ' ' : show c ++ ")"
@@ -96,9 +83,6 @@ data PickInst = PickInst {
                , addText :: Maybe (Map Language String)
                }
   deriving (Data, Eq, Generic, Show)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 dPickInst :: PickInst
 dPickInst =  PickInst
@@ -117,9 +101,6 @@ data MaxInst = MaxInst {
                , unicodeAllowed :: Bool
                }
   deriving (Data, Generic, Show)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 dMaxInst :: MaxInst
 dMaxInst =  MaxInst
@@ -139,9 +120,6 @@ data MinInst = MinInst {
                , unicodeAllowed :: Bool
                }
   deriving (Data, Generic, Show)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 dMinInst :: MinInst
 dMinInst =  MinInst
@@ -161,9 +139,6 @@ data FillInst = FillInst {
                , addText :: Maybe (Map Language String)
                }
   deriving (Data, Generic, Show)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 dFillInst :: FillInst
 dFillInst =  FillInst
@@ -183,9 +158,6 @@ data DecideInst = DecideInst {
                , addText :: Maybe (Map Language String)
                }
   deriving (Data, Generic, Show)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 dDecideInst :: DecideInst
 dDecideInst =  DecideInst
@@ -207,9 +179,6 @@ data StepInst = StepInst {
                , unicodeAllowed :: Bool
                }
   deriving (Data, Generic, Show)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 dStepInst :: StepInst
 dStepInst =  StepInst
@@ -234,9 +203,6 @@ data ResolutionInst = ResolutionInst {
                , unicodeAllowed :: Bool
                }
   deriving (Data, Generic, Show)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 dResInst :: ResolutionInst
 dResInst = let
@@ -279,9 +245,6 @@ data PrologInst = PrologInst {
                , addText :: Maybe (Map Language String)
                }
   deriving (Data, Generic, Show)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 
 dPrologInst :: PrologInst
@@ -303,9 +266,6 @@ data BaseConfig = BaseConfig
     , usedAtoms :: String
     }
   deriving (Generic, Show)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 
 dBaseConf :: BaseConfig
@@ -323,9 +283,6 @@ data NormalFormConfig = NormalFormConfig
     , maxClauseAmount :: Int
     }
   deriving (Generic, Show)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 dNormalFormConf :: NormalFormConfig
 dNormalFormConf = NormalFormConfig
@@ -345,9 +302,6 @@ data PickConfig = PickConfig {
      , extraText :: Maybe (Map Language String)
      }
   deriving (Generic, Show)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 dPickConf :: PickConfig
 dPickConf = PickConfig
@@ -368,9 +322,6 @@ data FillConfig = FillConfig {
     , extraText :: Maybe (Map Language String)
     }
   deriving (Generic, Show)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 dFillConf :: FillConfig
 dFillConf = FillConfig
@@ -391,9 +342,6 @@ data MinMaxConfig = MinMaxConfig {
     , offerUnicodeInput :: Bool
     }
   deriving (Generic, Show)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 dMinMaxConf :: MinMaxConfig
 dMinMaxConf = MinMaxConfig
@@ -414,9 +362,6 @@ data DecideConfig = DecideConfig {
     , extraText :: Maybe (Map Language String)
     }
   deriving (Generic, Show)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 dDecideConf :: DecideConfig
 dDecideConf = DecideConfig
@@ -437,9 +382,6 @@ data StepConfig = StepConfig {
     , offerUnicodeInput :: Bool
     }
   deriving (Generic, Show)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 dStepConf :: StepConfig
 dStepConf = StepConfig
@@ -463,9 +405,6 @@ data PrologConfig = PrologConfig {
     , useSetNotation :: Bool
     }
   deriving (Generic, Show)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 dPrologConf :: PrologConfig
 dPrologConf = PrologConfig
@@ -490,9 +429,6 @@ data ResolutionConfig = ResolutionConfig {
     , offerUnicodeInput :: Bool
     }
   deriving (Generic, Show)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 dResConf :: ResolutionConfig
 dResConf = ResolutionConfig

--- a/src/Formula/Types.hs
+++ b/src/Formula/Types.hs
@@ -1,10 +1,6 @@
 {-# OPTIONS_GHC -Wwarn=x-partial #-}
-{-# LANGUAGE CPP #-}
 {-# language DeriveDataTypeable #-}
 {-# language DeriveGeneric #-}
-#if !MIN_VERSION_base(4,18,0)
-{-# LANGUAGE DerivingStrategies #-}
-#endif
 {-# language DuplicateRecordFields #-}
 
 -- | Some basic types for propositional logic
@@ -50,9 +46,6 @@ import qualified SAT.MiniSat as Sat
 import Data.Data (Data)
 import Data.List(intercalate, delete, nub, transpose, (\\))
 import Data.Set (Set,empty)
-#if !MIN_VERSION_base(4,18,0)
-import Data.Typeable (Typeable)
-#endif
 import GHC.Generics
 import Test.QuickCheck hiding (Positive,Negative)
 import Numeric.SpecFunctions as Math (choose)
@@ -63,9 +56,6 @@ newtype ResStep = Res {
 
 newtype TruthValue = TruthValue {truth :: Bool}
   deriving (Eq, Generic, Ord, Show)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 
 
@@ -102,9 +92,6 @@ data Literal
       , Generic -- ^ derived
       , Data -- ^ derived
       )
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable -- ^ derived
-#endif
 
 
 -- | order literals alphabetically first, then prefer a positive sign
@@ -165,9 +152,6 @@ opposite (Negative l) = Positive l
 -- | A datatype representing a clause
 newtype Clause = Clause { literalSet :: Set Literal}
   deriving (Data, Eq, Generic)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 
 
@@ -231,9 +215,6 @@ type Allocation = [(Char, Bool)]
 -- | A datatype representing a formula in conjunctive normal form.
 newtype Cnf = Cnf { clauseSet :: Set Clause}
   deriving (Data, Eq, Generic)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 
 
@@ -319,9 +300,6 @@ genCnf (minNum,maxNum) (minLen,maxLen) atoms enforceUsingAllLiterals = do
 -- | A datatype representing a conjunction
 newtype Con = Con { literalSet :: Set Literal}
   deriving (Data, Eq, Generic)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 
 
@@ -382,9 +360,6 @@ genCon (minLength,maxLength) atoms = do
 -- | A datatype representing a formula in disjunctive normal form.
 newtype Dnf = Dnf { clauseSet :: Set Con}
   deriving (Data, Eq, Generic)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 
 
@@ -471,9 +446,6 @@ data Table = Table
     , getEntries :: [Maybe Bool]
     }
   deriving (Generic, Ord)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 
 
@@ -559,9 +531,6 @@ data PrologLiteral = PrologLiteral
     , constants :: [String]
     }
   deriving (Data, Eq, Generic)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 positivePLit :: String -> [String] -> PrologLiteral
 positivePLit = PrologLiteral True
@@ -589,9 +558,6 @@ instance Show PrologLiteral where
 
 newtype PrologClause = PrologClause {pLiterals :: Set PrologLiteral}
   deriving (Data, Eq, Generic)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 
 

--- a/src/Tasks/ComposeFormula/Config.hs
+++ b/src/Tasks/ComposeFormula/Config.hs
@@ -1,9 +1,5 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
-#if !MIN_VERSION_base(4,18,0)
-{-# LANGUAGE DerivingStrategies #-}
-#endif
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE FlexibleContexts #-}
 
@@ -21,9 +17,6 @@ import Data.Data (Data)
 import Data.Map (Map)
 import qualified Data.Map as Map (fromList)
 import Trees.Types (SynTree(..), BinOp(..))
-#if !MIN_VERSION_base(4,18,0)
-import Data.Typeable (Typeable)
-#endif
 import GHC.Generics
 import Control.OutputCapable.Blocks (LangM, Language, OutputCapable, english, german)
 import LogicTasks.Helpers (reject)
@@ -39,9 +32,6 @@ data ComposeFormulaConfig = ComposeFormulaConfig {
     , offerUnicodeInput :: Bool
     }
   deriving (Generic, Show)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 defaultComposeFormulaConfig :: ComposeFormulaConfig
 defaultComposeFormulaConfig = ComposeFormulaConfig
@@ -88,6 +78,3 @@ data ComposeFormulaInst = ComposeFormulaInst
                , unicodeAllowed :: Bool
                }
   deriving (Data, Generic, Show)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif

--- a/src/Tasks/DecomposeFormula/Config.hs
+++ b/src/Tasks/DecomposeFormula/Config.hs
@@ -1,8 +1,4 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveGeneric #-}
-#if !MIN_VERSION_base(4,18,0)
-{-# LANGUAGE DerivingStrategies #-}
-#endif
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE FlexibleContexts #-}
 
@@ -17,9 +13,6 @@ import Tasks.SynTree.Config (SynTreeConfig(..), defaultSynTreeConfig, checkSynTr
 import Data.Map (Map)
 import qualified Data.Map as Map (fromList, findWithDefault)
 import Trees.Types (SynTree(..), BinOp(..))
-#if !MIN_VERSION_base(4,18,0)
-import Data.Typeable (Typeable)
-#endif
 import GHC.Generics
 import Control.OutputCapable.Blocks (LangM, Language, OutputCapable, german, english)
 import LogicTasks.Helpers (reject)
@@ -31,9 +24,6 @@ data DecomposeFormulaConfig = DecomposeFormulaConfig {
     , offerUnicodeInput :: Bool
     }
   deriving (Generic, Show)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 defaultDecomposeFormulaConfig :: DecomposeFormulaConfig
 defaultDecomposeFormulaConfig = DecomposeFormulaConfig
@@ -78,6 +68,3 @@ data DecomposeFormulaInst = DecomposeFormulaInst
                , unicodeAllowed :: Bool
                }
   deriving (Generic, Show)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif

--- a/src/Tasks/TreeToFormula/Config.hs
+++ b/src/Tasks/TreeToFormula/Config.hs
@@ -1,8 +1,4 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveGeneric #-}
-#if !MIN_VERSION_base(4,18,0)
-{-# LANGUAGE DerivingStrategies #-}
-#endif
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE FlexibleContexts #-}
 
@@ -16,9 +12,6 @@ module Tasks.TreeToFormula.Config (
 import Tasks.SynTree.Config (SynTreeConfig(..), defaultSynTreeConfig, checkSynTreeConfig)
 import Data.Map (Map)
 import Trees.Types (SynTree(..), BinOp(..))
-#if !MIN_VERSION_base(4,18,0)
-import Data.Typeable (Typeable)
-#endif
 import GHC.Generics
 import Control.OutputCapable.Blocks (LangM, Language, OutputCapable)
 
@@ -29,9 +22,6 @@ data TreeToFormulaConfig = TreeToFormulaConfig {
     , offerUnicodeInput :: Bool
     }
   deriving (Generic, Show)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 defaultTreeToFormulaConfig :: TreeToFormulaConfig
 defaultTreeToFormulaConfig = TreeToFormulaConfig
@@ -58,6 +48,3 @@ data TreeToFormulaInst = TreeToFormulaInst {
                , unicodeAllowed :: Bool
                }
   deriving (Generic, Show)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif


### PR DESCRIPTION
`Typeable` is automatically derived since GHC 7.10 (10 years ago). We decided to drop the CPP directives and instead delete the deriving statements.