### PR TITLE
Generalize resolution task description for multiple inputs

### DIFF
--- a/src/LogicTasks/Semantics/Resolve.hs
+++ b/src/LogicTasks/Semantics/Resolve.hs
@@ -143,7 +143,7 @@ descriptionMultipleFields explainEmptySteps resInst@ResolutionInst{..} = baseDes
       german "Ein Schritt besteht aus den zwei verwendeten Klauseln sowie der daraus entstehenden Resolvente."
       german "Füllen Sie für jeden Schritt die leeren Eingabefelder aus. "
       english "Provide the solution as a sequence of steps. "
-      english "A step consists of the two used clauses and the resulting resolvent."
+      english "A step consists of the two clauses used and the resulting resolvent."
       english "Fill in the empty input fields for each step. "
       explainEmptySteps
     )


### PR DESCRIPTION
So it also fits with a new variant of the task that prefills some of the inputs instead of of always having three fields per step.