### PR TITLE
Change task description order in resolution step tasks

### DIFF
--- a/src/LogicTasks/Semantics/Prolog.hs
+++ b/src/LogicTasks/Semantics/Prolog.hs
@@ -83,26 +83,25 @@ description PrologInst{..} = do
     german "Geben Sie das in dem Resolutionsschritt genutzte Literal (in positiver oder negativer Form) und das Ergebnis in der folgenden Tupelform an: (Literal, Resolvente)."
     english "Provide the literal (in positive or negative form) used for the step and the resolvent in the following tuple form: (literal, resolvent)."
 
-  paragraph $ translate $ do
-    german "Die leere Klausel kann durch geschweifte Klammern '{ }' dargestellt werden."
-    english "The empty clause can be denoted by curly braces '{ }'."
-
-  paragraph $ indent $ if usesSetNotation
+  paragraph $ if usesSetNotation
     then do
       translate $ do
         german "Nutzen Sie zur Angabe der Klauseln die Mengenschreibweise. Ein Lösungsversuch mit den Klauseln {a(x), b(x)} und {-a(x), b(x), c(x)} könnte beispielsweise so aussehen:"
         english "Specify the clauses using set notation. A valid solution with the clauses {a(x), b(x)} and {-a(x), b(x), c(x)} could look like this:"
-      code "(a(x), { b(x), c(x) })"
+      indent $ code "(a(x), { b(x), c(x) })"
       pure ()
     else do
       translate $ do
         german "Nutzen Sie zur Angabe der Klauseln eine Formel. Ein Lösungsversuch mit den Klauseln 'a(x) oder b(x)' und '-a(x) oder b(x) oder c(x)' könnte beispielsweise so aussehen:"
         english "Specify the clauses using a formula. A valid solution with the clauses 'a(x) or b(x)' and '-a(x) or b(x) or c(x)' could look like this:"
-      translatedCode $ flip localise $ translations $ do
+      indent $ translatedCode $ flip localise $ translations $ do
         english "(a(x), b(x) or c(x))"
         german "(a(x), b(x) oder c(x))"
       pure ()
 
+  paragraph $ translate $ do
+    german "Die leere Klausel kann durch geschweifte Klammern '{ }' dargestellt werden."
+    english "The empty clause can be denoted by curly braces '{ }'."
 
   extra addText
   pure ()

--- a/src/LogicTasks/Semantics/Step.hs
+++ b/src/LogicTasks/Semantics/Step.hs
@@ -68,6 +68,19 @@ description oneInput StepInst{..} = do
     german $ "Geben Sie das in dem Resolutionsschritt genutzte Literal (in positiver oder negativer Form) und das Ergebnis" ++ gerEnd
     english $ "Provide the literal (in positive or negative form) used for the step and the resolvent" ++ engEnd
 
+  when usesSetNotation $ paragraph $ do
+    translate $ do
+      german "Nutzen Sie zur Angabe der Resolvente die Mengenschreibweise! Ein Lösungsversuch könnte beispielsweise so aussehen: "
+      english "Specify the resolvent using set notation! A valid solution could look like this: "
+    indent $ translatedCode $ flip localise $ translations setExample
+    pure ()
+
+  unless usesSetNotation $ paragraph $ do
+    translate $ do
+      german "Nutzen Sie zur Angabe der Resolvente eine Formel! Ein Lösungsversuch könnte beispielsweise so aussehen: "
+      english "Specify the resolvent using a formula! A valid solution could look like this: "
+    indent $ translatedCode $ flip localise $ translations exampleCode
+    pure ()
 
   keyHeading
   negationKey unicodeAllowed
@@ -79,21 +92,6 @@ description oneInput StepInst{..} = do
       english "Non-empty clause:"
     code "{ ... }"
     pure ()
-
-  when usesSetNotation $ paragraph $ indent $ do
-    translate $ do
-      german "Nutzen Sie zur Angabe der Resolvente die Mengenschreibweise! Ein Lösungsversuch könnte beispielsweise so aussehen: "
-      english "Specify the resolvent using set notation! A valid solution could look like this: "
-    translatedCode $ flip localise $ translations setExample
-    pure ()
-
-  unless usesSetNotation $ paragraph $ indent $ do
-    translate $ do
-      german "Nutzen Sie zur Angabe der Resolvente eine Formel! Ein Lösungsversuch könnte beispielsweise so aussehen: "
-      english "Specify the resolvent using a formula! A valid solution could look like this: "
-    translatedCode $ flip localise $ translations exampleCode
-    pure ()
-
 
   extra addText
   pure ()


### PR DESCRIPTION
closes #319

What it looks like now:

## Normal

<img width="2439" height="1134" alt="Screenshot From 2025-11-27 15-47-12" src="https://github.com/user-attachments/assets/a38fa4aa-1249-4a57-b007-96edc0516b93" />

## Prolog

<img width="2416" height="829" alt="Screenshot From 2025-11-27 15-47-43" src="https://github.com/user-attachments/assets/5c7ed1e1-a44b-4af4-acd6-b1b8eb6c4cb9" />

## Note

I had to slightly change the formatting. Due to the position changes, the indented paragraphs were placed directly under unrelated text, insinuating a "heading -> subtext" relationship.
