### PR TITLE
hide plain Config module

### DIFF
--- a/examples/src/Semantics/Resolution/PrologStep/Config.hs
+++ b/examples/src/Semantics/Resolution/PrologStep/Config.hs
@@ -2,7 +2,7 @@ module Semantics.Resolution.PrologStep.Config where
 
 import Test.Hspec
 
-import Config (
+import LogicTasks.Config (
   PrologConfig(..)
   )
 import Formula.Types (positivePLit, queryClause, procedureClause)

--- a/examples/src/Util/VerifyConfig.hs
+++ b/examples/src/Util/VerifyConfig.hs
@@ -7,7 +7,7 @@ module Util.VerifyConfig where
 import Control.OutputCapable.Blocks (LangM, OutputCapable, Language(German))
 import Test.Hspec
 import Type.Reflection
-import Config (FormulaConfig(..))
+import LogicTasks.Config (FormulaConfig(..))
 import LogicTasks.Util (checkNormalFormConfig)
 import Tasks.SynTree.Config (checkSynTreeConfig)
 import Control.OutputCapable.Blocks.Debug (checkConfigWith)

--- a/logic-tasks.cabal
+++ b/logic-tasks.cabal
@@ -68,13 +68,13 @@ library
       Formula.Helpers
       Formula.Printing
       ParsingHelpers
-      Config
       Formula.Types
       Formula.Resolution
       Formula.Util
       Util
   other-modules:
       Auxiliary
+      Config
       Formula.Parsing.Delayed.Internal
       Formula.Table
       LogicTasks.Helpers

--- a/package.yaml
+++ b/package.yaml
@@ -87,7 +87,6 @@ library:
     - Formula.Helpers
     - Formula.Printing
     - ParsingHelpers
-    - Config
     - Formula.Types
     - Formula.Resolution
     - Formula.Util

--- a/test/DecideSpec.hs
+++ b/test/DecideSpec.hs
@@ -6,7 +6,7 @@ module DecideSpec where
 import Test.Hspec
 import Test.QuickCheck (forAll, Gen, chooseInt, suchThat, elements)
 import Control.OutputCapable.Blocks (LangM, Rated)
-import Config (dDecideConf, DecideConfig (..), DecideInst (..), FormulaConfig(..), DecideChoice (..))
+import LogicTasks.Config (dDecideConf, DecideConfig (..), DecideInst (..), FormulaConfig(..), DecideChoice (..))
 import LogicTasks.Semantics.Decide (verifyQuiz, genDecideInst, verifyStatic, description, partialGrade, completeGrade)
 import Data.Maybe (fromMaybe)
 import SynTreeSpec (validBoundsSynTreeConfig)

--- a/test/FillSpec.hs
+++ b/test/FillSpec.hs
@@ -6,7 +6,7 @@ module FillSpec where
 import Test.Hspec
 import Test.QuickCheck (forAll, Gen, chooseInt, elements, suchThat, sublistOf)
 import Control.OutputCapable.Blocks (LangM, Rated)
-import Config (
+import LogicTasks.Config (
   dFillConf,
   FillConfig (..),
   FillInst (..),

--- a/test/LegalNormalFormSpec.hs
+++ b/test/LegalNormalFormSpec.hs
@@ -12,7 +12,7 @@ import ParsingHelpers (fully)
 import Formula.Types (Cnf, genCnf, genDnf, Dnf)
 import Formula.Parsing (parser)
 import Text.ParserCombinators.Parsec (ParseError, parse)
-import Config (NormalFormConfig(..), BaseConfig(..))
+import LogicTasks.Config (NormalFormConfig(..), BaseConfig(..))
 import Trees.Types (SynTree(..), BinOp(..))
 import Trees.Helpers (cnfToSynTree, dnfToSynTree)
 import Tasks.LegalNormalForm.Config (

--- a/test/MinMaxSpec.hs
+++ b/test/MinMaxSpec.hs
@@ -8,7 +8,7 @@ import Control.OutputCapable.Blocks (LangM)
 import Test.QuickCheck (Gen, chooseAny, forAll)
 import qualified LogicTasks.Semantics.Max as Max (verifyQuiz, verifyStatic, genMaxInst, description, partialGrade', completeGrade')
 import qualified LogicTasks.Semantics.Min as Min (verifyQuiz, verifyStatic, genMinInst, description, partialGrade', completeGrade')
-import Config (
+import LogicTasks.Config (
   MinMaxConfig(..),
   dMinMaxConf,
   MaxInst (cnf),

--- a/test/ParsingSpec.hs
+++ b/test/ParsingSpec.hs
@@ -10,7 +10,7 @@ import Trees.Parsing (formulaParse)
 
 import Text.Parsec (parse)
 import Formula.Types (ResStep)
-import Config (dPickInst, PickInst(..), FormulaInst (InstDnf, InstArbitrary))
+import LogicTasks.Config (dPickInst, PickInst(..), FormulaInst (InstDnf, InstArbitrary))
 import Text.PrettyPrint.Leijen.Text (Pretty(pretty))
 import Formula.Printing ()
 import qualified Trees.Types as TT (SynTree(Binary, Leaf, Not), BinOp (And))

--- a/test/PickSpec.hs
+++ b/test/PickSpec.hs
@@ -3,7 +3,7 @@
 module PickSpec where
 import Control.OutputCapable.Blocks (LangM)
 import Test.Hspec (Spec, describe, it)
-import Config (dPickConf, PickConfig (..), PickInst (..), FormulaConfig(..), Number (Number))
+import LogicTasks.Config (dPickConf, PickConfig (..), PickInst (..), FormulaConfig(..), Number (Number))
 import LogicTasks.Semantics.Pick (verifyQuiz, genPickInst, verifyStatic, description, partialGrade, completeGrade)
 import Data.Maybe (fromMaybe)
 import Test.QuickCheck (Gen, chooseInt, forAll, suchThat, elements)

--- a/test/PrologSpec.hs
+++ b/test/PrologSpec.hs
@@ -2,7 +2,7 @@
 module PrologSpec where
 import Test.Hspec
 import LogicTasks.Semantics.Prolog (genPrologInst, verifyQuiz, description, verifyStatic, partialGrade', completeGrade')
-import Config (dPrologConf, PrologInst (..), PrologConfig (..))
+import LogicTasks.Config (dPrologConf, PrologInst (..), PrologConfig (..))
 import Formula.Helpers (hasTheClauseShape)
 import Test.QuickCheck
 import Control.OutputCapable.Blocks (LangM)

--- a/test/ResolutionSpec.hs
+++ b/test/ResolutionSpec.hs
@@ -7,7 +7,7 @@ import Formula.Resolution (applySteps)
 import Data.Maybe (isJust, fromJust, isNothing)
 import Formula.Types (Clause(Clause), Literal (..), Formula (literals))
 import qualified Data.Set
-import Config (ResolutionConfig (..), BaseConfig (..), dResConf, ResolutionInst(solution, clauses))
+import LogicTasks.Config (ResolutionConfig (..), BaseConfig (..), dResConf, ResolutionInst(solution, clauses))
 import Test.QuickCheck (Gen, chooseInt, suchThat, forAll)
 import LogicTasks.Semantics.Resolve (verifyQuiz, genResInst, completeGrade', partialGrade', description, verifyStatic)
 import Control.OutputCapable.Blocks (LangM)

--- a/test/StepSpec.hs
+++ b/test/StepSpec.hs
@@ -4,7 +4,7 @@ import Test.Hspec (Spec, describe, it)
 import Control.OutputCapable.Blocks (LangM)
 import TestHelpers (doesNotRefuse)
 import Test.QuickCheck (forAll)
-import Config (StepInst(solution), dStepConf, StepAnswer (StepAnswer))
+import LogicTasks.Config (StepInst(solution), dStepConf, StepAnswer (StepAnswer))
 import LogicTasks.Semantics.Step (verifyQuiz, genStepInst, description, verifyStatic, partialGrade', completeGrade')
 
 


### PR DESCRIPTION
We export both `Config` and `LogicTasks.Config`. These modules are currently identical for users (the qualified version just re-exports).

I think it would be best to not expose plain `Config`, since this name is not very unique and already clashed with some other library when using it in Flex-Tasks.