### PR TITLE
Adjust to flex-task change to dropdowns and radio buttons

### DIFF
--- a/flex/markierungsalg.flex
+++ b/flex/markierungsalg.flex
@@ -138,8 +138,7 @@ form :: Rendered Widget
 form = formify (Nothing :: Maybe ([Maybe String], SingleChoiceSelection, Maybe String))
     [ [ list Vertical (map (fieldSettingsLabel . Step) [1..stepFields])]
     , [ dropdown (fieldSettingsLabel Output)
-        [ "---"
-        , SomeMessage Satisfiable
+        [ SomeMessage Satisfiable
         , SomeMessage Unsatisfiable
         ]
     , single (fieldSettingsLabel Model)
@@ -201,10 +200,7 @@ checkSyntax TaskData{..} Submission{..} = do
     checking (any isJust (dropWhile isJust steps)) $ do
         german "Es dürfen keine Schritte übersprungen werden."
         english "Steps cannot be skipped."
-    checking (getAnswer output == Just 1) $ do
-        german "Es muss eine Ausgabe für den Algorithmus ausgewählt werden."
-        english "An output option needs to be selected."
-    checking (getAnswer output == Just 3 && isJust model) $ do
+    checking (getAnswer output == 2 && isJust model) $ do
         german $ "Widerspruch gefunden: " ++
             "Die Formel sei unerfüllbar, dennoch wurde eine erfüllende Belegung (Modell) angegeben."
         english $ "Contradiction found: " ++
@@ -227,9 +223,9 @@ checkSyntax TaskData{..} Submission{..} = do
   where
     stepsSubmitted = zip [1..] (map unCharAnswer (catMaybes steps))
     (germanOutput, englishOutput) = case getAnswer output of
-      Just 3 -> ("\\"unerfüllbar\\"","\\"unsatisfiable\\"")
-      Just 2 -> ("\\"erfüllbar\\"","\\"satisfiable\\"")
-      _      -> ("","")
+      2 -> ("\\"unerfüllbar\\"","\\"unsatisfiable\\"")
+      1 -> ("\\"erfüllbar\\"","\\"satisfiable\\"")
+      _ -> ("","")
     (germanWith, englishWith, modelDisplay) = case model of
       Nothing -> ("","",pure ())
       Just m  -> ( ", mit"
@@ -246,7 +242,7 @@ checkSemantics _ TaskData{solution = Solution{..},..} Submission{..} = do
     yesNo stepsCorrect $ translate $ do
         german "Schritte richtig?"
         english "Steps correct?"
-    let outputCorrect = Just (if correctOutput then 2 else 3) == getAnswer output
+    let outputCorrect = (if correctOutput then 1 else 2) == getAnswer output
     yesNo outputCorrect $ translate $ do
         german "Ausgabe richtig?"
         english "Output correct?"

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -65,16 +65,22 @@ instance Show StepAnswer where
 data DecideChoice
   = Correct
   | Wrong
-  | NoAnswer
   deriving (Show,Ord,Eq,Enum,Bounded,Generic)
+
+newtype DecideAnswer
+  = DecideAnswer { maybeChoice :: Maybe DecideChoice}
+  deriving (Generic)
 
 showChoice :: Language -> DecideChoice -> String
 showChoice German Correct = "Richtig"
 showChoice German Wrong = "Fehlerhaft"
-showChoice German NoAnswer = "Keine Antwort"
 showChoice English Correct = "Correct"
 showChoice English Wrong = "Wrong"
-showChoice English NoAnswer = "No answer"
+
+showDecideAnswer :: Language -> DecideAnswer -> String
+showDecideAnswer German (DecideAnswer Nothing) = "Keine Antwort"
+showDecideAnswer English (DecideAnswer Nothing) = "No answer"
+showDecideAnswer lang (DecideAnswer (Just choice)) = showChoice lang choice
 
 data PickInst = PickInst {
                  formulas :: [FormulaInst]

--- a/src/Formula/Parsing.hs
+++ b/src/Formula/Parsing.hs
@@ -394,18 +394,18 @@ instance Parse FormulaInst where
         tokenSymbol "}"
         pure $ InstArbitrary f
 
-instance Parse DecideChoice where
-  parser = lexeme (try parseCorrect <|> try parseWrong <|> parseNoAnswer)
+instance Parse DecideAnswer where
+  parser = DecideAnswer <$> lexeme (try parseCorrect <|> try parseWrong <|> parseNoAnswer)
     where
-      parseCorrect = Correct <$
+      parseCorrect = Just Correct <$
           ( try (caseInsensitive "Richtig")
         <|> caseInsensitive "Correct"
           )
-      parseWrong = Wrong <$
+      parseWrong = Just Wrong <$
           ( try (caseInsensitive "Fehlerhaft")
         <|> caseInsensitive "Wrong"
           )
-      parseNoAnswer = NoAnswer <$
+      parseNoAnswer = Nothing <$
           ( try (lexeme (caseInsensitive "Keine") <* caseInsensitive "Antwort")
         <|> (lexeme (caseInsensitive "No") <* caseInsensitive "answer")
           )

--- a/src/LogicTasks/Semantics/Decide.hs
+++ b/src/LogicTasks/Semantics/Decide.hs
@@ -29,7 +29,16 @@ import Data.List.Extra ((\\), intercalate)
 import Data.Map (Map, fromList)
 import Test.QuickCheck (Gen, suchThat)
 
-import Config (DecideConfig(..), DecideInst(..), FormulaConfig (..), FormulaInst (..), DecideChoice (..), showChoice)
+import Config (
+  DecideConfig(..),
+  DecideInst(..),
+  FormulaConfig (..),
+  FormulaInst (..),
+  DecideAnswer(..),
+  DecideChoice (..),
+  showChoice,
+  showDecideAnswer
+  )
 import Formula.Table (flipAt, readEntries)
 import Formula.Types (atomics, availableLetter, getTable)
 import Util (isOutside, remove, withRatio, checkTruthValueRangeAndFormulaConf, formulaDependsOnAllAtoms)
@@ -90,8 +99,8 @@ description withDropdowns DecideInst{..} = do
           german "Betrachten Sie dazu die folgende Darstellung der Wahrheitstafel. "
           german "Neben jeder Zeile befindet sich ein Auswahlmenü mit diesen drei Optionen:"
         translatedCode $ flip localise $ translations $ do
-          english $ intercalate ", " $ map (showChoice English) [Correct,Wrong,NoAnswer]
-          german $ intercalate ", " $ map (showChoice German) [Correct,Wrong,NoAnswer]
+          english $ printDecideAnswers English options
+          german $ printDecideAnswers German options
         translate $ do
           english "Choose the appropriate answer for each row."
           german "Wählen Sie für jede Zeile die passende Antwort aus."
@@ -106,8 +115,8 @@ description withDropdowns DecideInst{..} = do
           german "Als Entscheidung stehen Ihnen die folgenden drei Optionen zur Verfügung:"
 
         translatedCode $ flip localise $ translations $ do
-          english $ intercalate ", " $ map (showChoice English) [Correct,Wrong,NoAnswer]
-          german $ intercalate ", " $ map (showChoice German) [Correct,Wrong,NoAnswer]
+          english $ printDecideAnswers English options
+          german $ printDecideAnswers German options
 
         translate $ do
           english "Make sure to assign a decision to each row. "
@@ -117,15 +126,18 @@ description withDropdowns DecideInst{..} = do
           german "Das n-te Listenelement entspricht der n-ten Zeile. "
           german "Ein Lösungsversuch für eine Tabelle mit vier Zeilen könnte so aussehen: "
         translatedCode $ flip localise $ translations $ do
-          english $ "[" ++ intercalate ", " (map (showChoice English) [Correct,Correct,Wrong,NoAnswer]) ++ "]"
-          german $ "[" ++ intercalate ", " (map (showChoice German) [Correct,Correct,Wrong,NoAnswer]) ++ "]"
+          english $ "[" ++ printDecideAnswers English exampleInput ++ "]"
+          german $ "[" ++ printDecideAnswers German exampleInput ++ "]"
 
         pure ()
 
       pure ()
   extra addText
   pure ()
-
+  where
+    printDecideAnswers lang = intercalate ", " . map (showDecideAnswer lang . DecideAnswer)
+    options = [Just Correct, Just Wrong, Nothing]
+    exampleInput = [Just Correct, Just Correct, Just Wrong, Nothing]
 
 verifyStatic :: OutputCapable m => DecideInst -> LangM m
 verifyStatic DecideInst{..}
@@ -171,10 +183,10 @@ verifyQuiz DecideConfig{..}
 
 
 
-start :: [DecideChoice]
-start = replicate 4 NoAnswer
+start :: [DecideAnswer]
+start = replicate 4 $ DecideAnswer Nothing
 
-partialGrade :: OutputCapable m =>  DecideInst -> [DecideChoice] -> LangM m
+partialGrade :: OutputCapable m =>  DecideInst -> [DecideAnswer] -> LangM m
 partialGrade inst sol
   | lengthDiff > 0 = reject $ do
       german "Die Anzahl der Listenelemente stimmt nicht mit der Anzahl an Zeilen überein. "
@@ -190,7 +202,7 @@ partialGrade inst sol
 completeGrade
   :: (OutputCapable m,Alternative m, Monad m)
   => DecideInst
-  -> [DecideChoice]
+  -> [DecideAnswer]
   -> Rated m
 completeGrade DecideInst{..} sol = reRefuse
   (withExtendedMultipleChoice
@@ -219,7 +231,7 @@ completeGrade DecideInst{..} sol = reRefuse
       code $ show table
       pure ()
     where
-      indexed = filter ((/=NoAnswer) . snd) $ zip [1..] sol
+      indexed = [ (index,c) | (index, DecideAnswer (Just c)) <- zip [1..] sol]
       solMap = fromList $ map (,True) indexed
       table = getTable formula
       tableLen = length $ readEntries table

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,7 +14,7 @@ extra-deps:
     subdirs:
       - output-blocks
   - git: https://github.com/fmidue/flex-tasks.git
-    commit: be94c9d50297a88385a63d6f9beaa544c14b67c8
+    commit: 14342cad179b3c7e4a440b90941557f730165ed7
     subdirs:
       - flex-tasks
       - flex-tasks-processing

--- a/test/DecideSpec.hs
+++ b/test/DecideSpec.hs
@@ -6,7 +6,7 @@ module DecideSpec where
 import Test.Hspec
 import Test.QuickCheck (forAll, Gen, chooseInt, suchThat)
 import Control.OutputCapable.Blocks (LangM, Rated)
-import Config (dDecideConf, DecideConfig (..), DecideInst (..), FormulaConfig(..), DecideChoice (..))
+import Config (dDecideConf, DecideConfig (..), DecideInst (..), FormulaConfig(..), DecideAnswer(..), DecideChoice (..))
 import LogicTasks.Semantics.Decide (verifyQuiz, genDecideInst, verifyStatic, description, partialGrade, completeGrade)
 import SynTreeSpec (validBoundsSynTreeConfig')
 import Formula.Types (Table(getEntries), getTable)
@@ -63,12 +63,12 @@ spec = do
           doesNotRefuse
             (partialGrade
               inst
-                [ if i `elem` changed inst then Wrong else Correct
+                [ DecideAnswer $ Just $ if i `elem` changed inst then Wrong else Correct
                 | i <- [1.. length $ getEntries $ getTable $ formula inst]] :: LangM Maybe) &&
           doesNotRefuse
             (completeGrade
               inst
-                [ if i `elem` changed inst then Wrong else Correct
+                [ DecideAnswer $ Just $ if i `elem` changed inst then Wrong else Correct
                 | i <- [1.. length $ getEntries $ getTable $ formula inst]] :: Rated Maybe)
     it "should generate an instance with the right amount of changed entries" $
       forAll validBoundsDecideConfig $ \decideConfig@DecideConfig{..} -> do


### PR DESCRIPTION
changes to `Decide`'s answer type are meant to make sharing this type for both the non-flex- and flex-task versions still possible.