### PR TITLE
Delete/Move to Autotool Parsing and Printing

### DIFF
--- a/src/Formula/Parsing.hs
+++ b/src/Formula/Parsing.hs
@@ -19,7 +19,6 @@ import ParsingHelpers (caseInsensitive, lexeme, tokenSymbol)
 import Formula.Types
 
 import Control.Monad (void)
-import Data.Map (fromList)
 import Text.ParserCombinators.Parsec (
   Parser,
   (<?>),
@@ -352,47 +351,6 @@ formulaListSymbolParser = void $ many $ logicToken <|> listSymbolParser
 
 instance Parse PrologClause where
  parser = prologClauseFormulaParser
-
-instance Parse PickInst where
-  parser = lexeme instParse
-    where
-      instParse = do
-        string "PickInst("
-        cs <- parser
-        tokenSymbol ","
-        index <- lexeme $ many1 digit
-        printSol <- lexeme text'
-        bonusText <- optionMaybe $ lexeme text'
-        char ')'
-        pure $ PickInst cs (read index) (read printSol) (fromList . read <$> bonusText)
-          where
-            text' = between start (char '}') $ many1 $ satisfy ( /= '}')
-            start = do
-              char ','
-              spaces
-              char '{'
-
-instance Parse FormulaInst where
-  parser = lexeme (parseCNF <|> parseDNF <|> parseSynTree)
-    where
-      parseCNF = do
-        string "Cnf"
-        tokenSymbol "{"
-        f <- (parser :: Parser Cnf)
-        tokenSymbol "}"
-        pure $ InstCnf f
-      parseDNF = do
-        string "Dnf"
-        tokenSymbol "{"
-        f <- (parser :: Parser Dnf)
-        tokenSymbol "}"
-        pure $ InstDnf f
-      parseSynTree = do
-        string "SynTree"
-        tokenSymbol "{"
-        f <- (parser :: Parser (SynTree BinOp Char))
-        tokenSymbol "}"
-        pure $ InstArbitrary f
 
 instance Parse DecideAnswer where
   parser = DecideAnswer <$> lexeme (try parseCorrect <|> try parseWrong <|> parseNoAnswer)

--- a/src/Formula/Parsing.hs
+++ b/src/Formula/Parsing.hs
@@ -39,7 +39,6 @@ import Text.ParserCombinators.Parsec (
   )
 
 import UniversalParser
-import Trees.Types (SynTree, BinOp)
 import Formula.Parsing.Type (Parse(..))
 import Trees.Parsing ()
 

--- a/src/Formula/Printing.hs
+++ b/src/Formula/Printing.hs
@@ -16,7 +16,6 @@ import Data.Text.Lazy (pack)
 import qualified Data.Set as Set (null)
 
 import Text.PrettyPrint.Leijen.Text
-import Data.Map (toList)
 import Data.Maybe (isJust, fromJust)
 import Trees.Print ()
 
@@ -138,24 +137,6 @@ instance Pretty PrologClause where
     pretty pc
         | Set.null (pLiterals pc) = text "{ }"
         | otherwise = hsep $ punctuate (text " ∨ ") $ map pretty $ terms pc
-
-
-
-instance Pretty PickInst where
-  pretty  PickInst{..} =
-      text "PickInst(" <> vcat
-                           [ nest 2 $ pretty formulas
-                           , char ',' <+> pretty correct
-                           , myText (", {" ++ show showSolution ++ "}")
-                           , maybe empty (\s -> myText (", {" ++ show (toList s) ++ "}")) addText
-                           , char ')'
-                           ]
-
-
-instance Pretty FormulaInst where
-  pretty (InstCnf cnf) = text "Cnf{" <> pretty cnf <> char '}'
-  pretty (InstDnf dnf) = text "Dnf{" <> pretty dnf <> char '}'
-  pretty (InstArbitrary tree) = text "SynTree{" <> pretty tree <> char '}'
 
 
 

--- a/src/Formula/Printing.hs
+++ b/src/Formula/Printing.hs
@@ -91,7 +91,7 @@ instance Pretty Cnf where
 
 
 instance Pretty Dnf where
-    pretty dnf = listShow $ getConjunctions dnf
+    pretty = listShow . getConjunctions
       where
         listShow [] = empty
         listShow [x] = singlePrint x

--- a/src/Formula/Printing.hs
+++ b/src/Formula/Printing.hs
@@ -1,6 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS_GHC -Wwarn=x-partial #-}
-{-# language RecordWildCards #-}
 {-# language OverloadedStrings #-}
 
 module Formula.Printing
@@ -75,7 +74,7 @@ instance Pretty Con where
 
 
 instance Pretty Cnf where
-    pretty cnf = listShow $ getClauses cnf
+    pretty = listShow . getClauses
       where
         listShow [] = empty
         listShow [x] = singlePrint x

--- a/test/ParsingSpec.hs
+++ b/test/ParsingSpec.hs
@@ -5,15 +5,12 @@ import Data.Either (isLeft, isRight)
 import Test.Hspec ( describe, it, Spec)
 
 import LogicTasks.Parsing (Parse(parser))
-import LogicTasks.Formula (Cnf, Dnf, mkDnf, mkCon, Literal (..))
+import LogicTasks.Formula (Cnf, Dnf)
 import Trees.Parsing (formulaParse)
 
 import Text.Parsec (parse)
 import Formula.Types (ResStep)
-import Config (dPickInst, PickInst(..), FormulaInst (InstDnf, InstArbitrary))
-import Text.PrettyPrint.Leijen.Text (Pretty(pretty))
 import Formula.Printing ()
-import qualified Trees.Types as TT (SynTree(Binary, Leaf, Not), BinOp (And))
 
 spec :: Spec
 spec = do
@@ -44,12 +41,3 @@ spec = do
   describe "parser @ResStep" $ do
     it "can handle extra whitespace in resolved clause" $
       isRight $ parse (parser @ResStep) "" "(1, 2, {   A   ,    nicht    B   } = 5)"
-  describe "parser @PickInst" $ do
-    it "correctly parses the pretty representation of a PickInst (cnf)" $
-      either (const False) (== dPickInst) $ parse (parser @PickInst) "" $ show $ pretty dPickInst
-    it "correctly parses the pretty representation of a PickInst (dnf)" $
-      let pickInst = dPickInst { formulas = [InstDnf (mkDnf [mkCon [Positive 'A', Negative 'B']])] } in
-        either (const False) (== pickInst) $ parse (parser @PickInst) "" $ show $ pretty pickInst
-    it "correctly parses the pretty representation of a PickInst (arbitrary)" $
-      let pickInst = dPickInst { formulas = [InstArbitrary (TT.Binary TT.And (TT.Leaf 'A') (TT.Not (TT.Leaf 'B')))] } in
-        either (const False) (== pickInst) $ parse (parser @PickInst) "" $ show $ pretty pickInst


### PR DESCRIPTION
This only deletes the custom parsing and printing for `PickInst` and `FormulaInst` for now. Those are truly unnecessary and can be directly replaced by derived `ToDoc` and `Reader` instances.

I'm not sure what to do for all of the delayed parsing based stuff.  A common pattern is this:

The `Parse` instance defined in this repo is used for calls of the delayed parsing in the task definitions, e.g.

  https://github.com/fmidue/logic-tasks/blob/3f7a9008567096f4d8a578de56ca34e74dc02344/src/LogicTasks/Syntax/ComposeFormula.hs#L137

  If we want to move all of the parsing defined for these types here to Autotool, then we will also need to move task logic like this over there.

For all of these delayed parsing tasks, the Pretty instances are actually completely unused. Instead, the tasks just call something like `PlainText $ show start` and use the `ToDoc` instance of `PlainText` (String newtype), so they rely on the `Show` instance instead.
So in principle, we could just completely delete most of the Pretty stuff instead of moving it over. But I wonder if we really should rely on `show` like that. Maybe we can still move the code over and replace the `show` calls with `render . toDoc`?