### PR TITLE
Decide: make explanation labels match the actual ones

### DIFF
--- a/src/Config.hs
+++ b/src/Config.hs
@@ -62,7 +62,7 @@ instance Show StepAnswer where
   show _ = ""
 
 data DecideChoice
-  = Correct
+  = Right
   | Wrong
   deriving (Show,Ord,Eq,Enum,Bounded,Generic)
 
@@ -71,9 +71,9 @@ newtype DecideAnswer
   deriving (Generic)
 
 showChoice :: Language -> DecideChoice -> String
-showChoice German Correct = "Richtig"
+showChoice German Right = "Richtig"
 showChoice German Wrong = "Fehlerhaft"
-showChoice English Correct = "Right"
+showChoice English Right = "Right"
 showChoice English Wrong = "Wrong"
 
 showDecideAnswer :: Language -> DecideAnswer -> String

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -73,12 +73,12 @@ newtype DecideAnswer
 showChoice :: Language -> DecideChoice -> String
 showChoice German Correct = "Richtig"
 showChoice German Wrong = "Fehlerhaft"
-showChoice English Correct = "Right"
+showChoice English Correct = "Correct"
 showChoice English Wrong = "Wrong"
 
 showDecideAnswer :: Language -> DecideAnswer -> String
-showDecideAnswer German (DecideAnswer Nothing) = "Keine Antwort"
-showDecideAnswer English (DecideAnswer Nothing) = "No answer"
+showDecideAnswer German (DecideAnswer Nothing) = "Nichts"
+showDecideAnswer English (DecideAnswer Nothing) = "None"
 showDecideAnswer lang (DecideAnswer (Just choice)) = showChoice lang choice
 
 data PickInst = PickInst {

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -5,6 +5,7 @@
 module Config where
 
 
+import Prelude hiding (Right)
 import Data.Data (Data)
 import GHC.Generics
 import Formula.Types

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -73,7 +73,7 @@ newtype DecideAnswer
 showChoice :: Language -> DecideChoice -> String
 showChoice German Correct = "Richtig"
 showChoice German Wrong = "Fehlerhaft"
-showChoice English Correct = "Correct"
+showChoice English Correct = "Right"
 showChoice English Wrong = "Wrong"
 
 showDecideAnswer :: Language -> DecideAnswer -> String

--- a/src/Formula/Parsing.hs
+++ b/src/Formula/Parsing.hs
@@ -363,6 +363,6 @@ instance Parse DecideAnswer where
         <|> caseInsensitive "Wrong"
           )
       parseNoAnswer = Nothing <$
-          ( try (lexeme (caseInsensitive "Keine") <* caseInsensitive "Antwort")
-        <|> (lexeme (caseInsensitive "No") <* caseInsensitive "answer")
+          ( try (caseInsensitive "Nichts")
+        <|> caseInsensitive "None"
           )

--- a/src/Formula/Parsing.hs
+++ b/src/Formula/Parsing.hs
@@ -13,7 +13,8 @@ module Formula.Parsing (
   prologClauseSetParser
   ) where
 
-import Config
+import Config hiding (Right)
+import qualified Config as DecideChoice (Right)
 import Formula.Util
 import ParsingHelpers (caseInsensitive, lexeme, tokenSymbol)
 import Formula.Types
@@ -354,9 +355,9 @@ instance Parse PrologClause where
 instance Parse DecideAnswer where
   parser = DecideAnswer <$> lexeme (try parseCorrect <|> try parseWrong <|> parseNoAnswer)
     where
-      parseCorrect = Just Correct <$
+      parseCorrect = Just DecideChoice.Right <$
           ( try (caseInsensitive "Richtig")
-        <|> caseInsensitive "Correct"
+        <|> caseInsensitive "Right"
           )
       parseWrong = Just Wrong <$
           ( try (caseInsensitive "Fehlerhaft")

--- a/src/Formula/Parsing.hs
+++ b/src/Formula/Parsing.hs
@@ -14,7 +14,7 @@ module Formula.Parsing (
   ) where
 
 import Config hiding (Right)
-import qualified Config as DecideChoice (Right)
+import qualified Config as DecideChoice (DecideChoice(Right))
 import Formula.Util
 import ParsingHelpers (caseInsensitive, lexeme, tokenSymbol)
 import Formula.Types

--- a/src/LogicTasks/Semantics/Decide.hs
+++ b/src/LogicTasks/Semantics/Decide.hs
@@ -137,7 +137,7 @@ description withDropdowns DecideInst{..} = do
   pure ()
   where
     printDecideAnswers lang = intercalate ", " . map (showDecideAnswer lang . DecideAnswer)
-    options = [Just Correct, Just Wrong, Nothing]
+    options = [Nothing, Just Correct, Just Wrong]
     exampleInput = [Just Correct, Just Correct, Just Wrong, Nothing]
 
 verifyStatic :: OutputCapable m => DecideInst -> LangM m

--- a/src/LogicTasks/Semantics/Decide.hs
+++ b/src/LogicTasks/Semantics/Decide.hs
@@ -30,6 +30,7 @@ import Data.List.Extra ((\\), intercalate)
 import Data.Map (Map, fromList)
 import Test.QuickCheck (Gen, suchThat)
 
+import Prelude hiding (Right)
 import Config (
   DecideConfig(..),
   DecideInst(..),

--- a/src/LogicTasks/Semantics/Decide.hs
+++ b/src/LogicTasks/Semantics/Decide.hs
@@ -137,8 +137,8 @@ description withDropdowns DecideInst{..} = do
   pure ()
   where
     printDecideAnswers lang = intercalate ", " . map (showDecideAnswer lang . DecideAnswer)
-    options = [Nothing, Just Correct, Just Wrong]
-    exampleInput = [Just Correct, Just Correct, Just Wrong, Nothing]
+    options = [Nothing, Just Right, Just Wrong]
+    exampleInput = [Just Right, Just Right, Just Wrong, Nothing]
 
 verifyStatic :: OutputCapable m => DecideInst -> LangM m
 verifyStatic DecideInst{..}
@@ -221,9 +221,9 @@ completeGrade DecideInst{..} sol = reRefuse
           german "Die korrekte Lösung ist:"
         translatedCode $ flip localise $ translations $ do
           english $
-            "[" ++ intercalate ", " (map (\i -> showChoice English $ if i `elem` changed then Wrong else Correct) [1..tableLen]) ++ "]"
+            "[" ++ intercalate ", " (map (\i -> showChoice English $ if i `elem` changed then Wrong else Right) [1..tableLen]) ++ "]"
           german $
-            "[" ++ intercalate ", " (map (\i -> showChoice German $ if i `elem` changed then Wrong else Correct) [1..tableLen]) ++ "]"
+            "[" ++ intercalate ", " (map (\i -> showChoice German $ if i `elem` changed then Wrong else Right) [1..tableLen]) ++ "]"
         pure ()
 
       paragraph $ translate $ do
@@ -238,9 +238,9 @@ completeGrade DecideInst{..} sol = reRefuse
       tableLen = length $ readEntries table
       restOf = [1..tableLen] \\ changed
       answerListWrong = map ((,True) . (,Wrong)) changed ++ map ((,False) . (,Wrong)) restOf
-      answerListCorrect = map ((,False) . (,Correct)) changed ++ map ((,True) . (,Correct)) restOf
+      answerListCorrect = map ((,False) . (,Right)) changed ++ map ((,True) . (,Right)) restOf
       correctOption (i,c) = case c of
-        Correct -> i `elem` restOf
+        Right -> i `elem` restOf
         _   -> i `elem` changed
 
       what = Just $ translations $ do

--- a/test/DecideSpec.hs
+++ b/test/DecideSpec.hs
@@ -63,12 +63,12 @@ spec = do
           doesNotRefuse
             (partialGrade
               inst
-                [ DecideAnswer $ Just $ if i `elem` changed inst then Wrong else Correct
+                [ DecideAnswer $ Just $ if i `elem` changed inst then Wrong else Right
                 | i <- [1.. length $ getEntries $ getTable $ formula inst]] :: LangM Maybe) &&
           doesNotRefuse
             (completeGrade
               inst
-                [ DecideAnswer $ Just $ if i `elem` changed inst then Wrong else Correct
+                [ DecideAnswer $ Just $ if i `elem` changed inst then Wrong else Right
                 | i <- [1.. length $ getEntries $ getTable $ formula inst]] :: Rated Maybe)
     it "should generate an instance with the right amount of changed entries" $
       forAll validBoundsDecideConfig $ \decideConfig@DecideConfig{..} -> do

--- a/test/DecideSpec.hs
+++ b/test/DecideSpec.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE RecordWildCards #-}
 module DecideSpec where
 
+import Prelude hiding (Right)
+
 -- jscpd:ignore-start
 import Test.Hspec
 import Test.QuickCheck (forAll, Gen, chooseInt, suchThat)


### PR DESCRIPTION
closes #371 

This also changes the non-form's input for "no answer" to `Nichts`/`None`. If that should be kept different at `NoAnswer`/`KeineAntwort`, then please let me know. 

